### PR TITLE
Handle wrong password. Fixes #4.

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,9 @@
         </div>
         <div class="form-group">
           <label class="control-label" for="password">WeeChat relay password</label>
+          <div class="alert alert-danger" ng-show="passwordError">
+            Error wrong password
+          </div>
           <input type="password" class="form-control" id="password" ng-model="password" placeholder="Password">
           <p class="help-block">Password will be stored in your browser session</p>
             </div>
@@ -138,6 +141,7 @@ $ openssl req -nodes -newkey rsa:2048 -keyout relay.pem -x509 -days 365 -out rel
       </div>
       <div class="push"></div>
     </div>
+        
     <div id="footer" ng-show="connected">
       <div class="navbar navbar-inverse navbar-fixed-bottom">
         <form class="form form-horizontal" ng-submit="sendMessage()">


### PR DESCRIPTION
This commit introduces a way to handle wrong password.

The only way to know it is by sending an other message after the init
one.
If we receive an answer to this second message id then we know we are
connected with the good password, otherwise we will received an onclose
event from the websocket.
