### PR TITLE
Enable speech recognition in Chrome for message input

### DIFF
--- a/directives/input.html
+++ b/directives/input.html
@@ -1,6 +1,6 @@
 <form class="form form-horizontal" ng-submit="sendMessage()">
   <div class="input-group">
-    <input id="sendMessage" type="text" class="form-control monospace" autocomplete="off" ng-model="command" autofocus>
+    <input id="sendMessage" type="text" class="form-control monospace" autocomplete="off" ng-model="command" autofocus x-webkit-speech>
     <span class="input-group-btn">
       <button class="btn btn-default btn-primary">Send</button>
     </span>


### PR DESCRIPTION
This micro-patch causes Chrome to add speech recognition to the message input field. It's as simple as adding "x-webkit-speech" to the <input> tag, and quite cool!
