### PR TITLE
Initialize lastread marker to last read line when initially fetching messages from server

### DIFF
--- a/js/models.js
+++ b/js/models.js
@@ -23,7 +23,7 @@ models.service('models', ['$rootScope', '$filter', function($rootScope, $filter)
         var active = false
         var notification = 0 
         var unread = 0
-        var lastSeen = -2
+        var lastSeen = -1
         var serverSortKey = fullName.replace(/^irc.server.(\w+)/, "irc.$1");
 
         var indent = function(predicate) {

--- a/js/websockets.js
+++ b/js/websockets.js
@@ -30,6 +30,10 @@ weechat.factory('handlers', ['$rootScope', 'models', 'plugins', function($rootSc
             message = plugins.PluginManager.contentForMessage(message, $rootScope.visible);
             buffer.addLine(message);
 
+            if (initial) {
+                buffer.lastSeen++;
+            }
+
             if (buffer.active) {
                 $rootScope.scrollToBottom();
             }


### PR DESCRIPTION
When opening up glowing bear, the read marker is currently initialised to the position before the first message (i.e. invisible). With this pull request, it is instead initialised to above the first unread message. Thus, if there are no unread messages, the lastread marker is at the very bottom of the messages. Otherwise, it is positioned above the first unread message. This is exact and also applies to join/leave messages etc.
