### PR TITLE
Improve mobile layout

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -320,9 +320,6 @@ input[type=text], input[type=password], .badge {
         min-width: 80px;
         padding: 15px;
     }
-    .hide-mobile {
-        display: none;
-    }
 }
 .color-light-green {
     color: chartreuse;


### PR DESCRIPTION
Building on torhve's work, add some more layout tweaks for mobile. Most importantly, remove that annoying side-scrolling.

We could consider guessing some things on mobile, i.e. automatically enabling the "hide nicklist" setting.
