### PR TITLE
Making compression optional was a stupid idea. Revert.

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,12 +72,6 @@
                         Encryption. Read instructions for help
                       </label>
                     </div>
-                    <div class="checkbox">
-                      <label class="control-label " for="compression">
-                        <input type="checkbox" class="" id="compression" ng-model="compression">
-                        Compress communication with relay
-                      </label>
-                    </div>
                   </div>
                   <div class="form-group">
                     <label class="control-label" for="port">Lines</label>

--- a/js/websockets.js
+++ b/js/websockets.js
@@ -276,7 +276,7 @@ weechat.factory('connection', ['$q', '$rootScope', '$log', '$store', 'handlers',
     };
 
     // Takes care of the connection and websocket hooks
-    var connect = function (host, port, passwd, ssl, compression) {
+    var connect = function (host, port, passwd, ssl, noCompression) {
         var proto = ssl ? 'wss':'ws';
         websocket = new WebSocket(proto+"://" + host + ':' + port + "/weechat");
         websocket.binaryType = "arraybuffer";
@@ -291,7 +291,7 @@ weechat.factory('connection', ['$q', '$rootScope', '$log', '$store', 'handlers',
             sendAll([
                 weeChat.Protocol.formatInit({
                     password: passwd,
-                    compression: compression ? 'zlib' : 'off'
+                    compression: noCompression ? 'off' : 'zlib'
                 }),
 
                 weeChat.Protocol.formatInfo({
@@ -532,7 +532,6 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     $store.bind($scope, "port", "9001");
     $store.bind($scope, "proto", "weechat");
     $store.bind($scope, "ssl", false);
-    $store.bind($scope, "compression", false);
     $store.bind($scope, "lines", "40");
     $store.bind($scope, "savepassword", false);
     if($scope.savepassword) {
@@ -601,7 +600,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
 
 
     $scope.connect = function() {
-        connection.connect($scope.host, $scope.port, $scope.password, $scope.ssl, $scope.compression);
+        connection.connect($scope.host, $scope.port, $scope.password, $scope.ssl);
     };
     $scope.disconnect = function() {
         connection.disconnect();

--- a/js/weechat.js
+++ b/js/weechat.js
@@ -630,7 +630,7 @@
     WeeChatProtocol.formatInit = function(params) {
         var defaultParams = {
             password: null,
-            compression: 'off'
+            compression: 'zlib'
         };
         var keys = [];
         var parts = [];


### PR DESCRIPTION
Instead, add a parameter to the connect function that allows disabling compression.

Or just enable compression all the time, no option in connect?
