### PR TITLE
Improve scrolling

### DIFF
--- a/js/websockets.js
+++ b/js/websockets.js
@@ -480,7 +480,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     }
 
     $rootScope.$on('activeBufferChanged', function() {
-        $rootScope.scrollWithBuffer();
+        $rootScope.scrollWithBuffer(true);
 
         var ab = models.getActiveBuffer();
         $rootScope.pageTitle = ab.shortName + ' | ' + ab.title;
@@ -577,14 +577,24 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         }
     };
 
-    $rootScope.scrollWithBuffer = function() {
-        // FIXME doesn't work if the settimeout runs without a short delay
+    $rootScope.scrollWithBuffer = function(nonIncremental) {
+        // First, get scrolling status *before* modification
+        // This is required to determine where we were in the buffer pre-change
+        var bl = document.getElementById('bufferlines');
+        var sVal = bl.scrollHeight - bl.clientHeight;
+
         var scroll = function() {
-            var bl = document.getElementById('bufferlines');
             var sTop = bl.scrollTop;
-            var sVal = bl.scrollHeight - bl.clientHeight;
-            if(sTop == sVal) {
-                bl.scrollTop = sVal;
+            // Determine if we want to scroll at all
+            if (nonIncremental && sTop < sVal || sTop == sVal) {
+                var readmarker = document.getElementById('readmarker');
+                if(nonIncremental && readmarker) {
+                    // Switching channels, scroll to read marker
+                    readmarker.scrollIntoView();
+                } else {
+                    // New message, scroll with buffer (i.e. to bottom)
+                    bl.scrollTop = bl.scrollHeight - bl.clientHeight;
+                }
             }
         };
         // Here be scrolling dragons


### PR DESCRIPTION
Only scroll if we're at the bottom of the buffer, otherwise things will jump. I consider this behaviour a lot more natural (and it's also how e.g. irssi and probably ncurses-WeeChat handle scrolling).

Closes #106.
