### PR TITLE
Reduce number of watchers

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,9 +266,9 @@ $ openssl req -nodes -newkey rsa:2048 -keyout relay.pem -x509 -days 365 -out rel
           </li>
           <li class="buffer" ng-class="{'active': content.active }" ng-repeat="(key, content) in buffers | toArray | filter:{fullName:search} | filter:hasUnread | orderBy:predicate">
             <a href="#" ng-click="setActiveBuffer(content.id)" title="{{ content.fullName }}">
-                <span class="badge pull-right" ng-hide="content.notification" ng-if="content.unread" ng-bind="content.unread"></span>
+              <span class="badge pull-right" ng-hide="content.notification" ng-if="content.unread" ng-bind="content.unread"></span>
               <span class="badge pull-right danger" ng-show="content.notification" ng-bind="content.notification"></span>
-              {{ content.indent(predicate) }}{{ content.shortName }}<span ng-hide="content.shortName">{{ content.fullName }}</span>
+              {{ content.indentedName(predicate) }}<span ng-hide="content.shortName">{{ content.fullName }}</span>
             </a>
           </li>
         </ul>

--- a/js/models.js
+++ b/js/models.js
@@ -28,12 +28,12 @@ models.service('models', ['$rootScope', '$filter', function($rootScope, $filter)
         var lastSeen = -1;
         var serverSortKey = fullName.replace(/^irc.server.(\w+)/, "irc.$1");
 
-        var indent = function(predicate) {
+        var indentedName = function(predicate) {
             if( predicate == "serverSortKey" && fullName.match(/^irc./) && !fullName.match(/^irc.server./) ) {
                 // indent channel
-                return "    "; // four protected spaces
+                return "    " + shortName; // four protected spaces
             } else {
-                return "";
+                return shortName;
             }
         };
 
@@ -173,7 +173,7 @@ models.service('models', ['$rootScope', '$filter', function($rootScope, $filter)
             updateNick: updateNick,
             flatNicklist: flatNicklist,
             serverSortKey: serverSortKey,
-            indent: indent,
+            indentedName: indentedName,
             history: history,
             addToHistory: addToHistory,
             getHistoryUp: getHistoryUp,


### PR DESCRIPTION
- Nicklist entries are only bound once (not the nicklist, but each entry → updates still work)
- the timestamp display is currently broken, remove a watcher that does not have any effect
- Reduce number of watchers per buffer in bufferlist by one
