### PR TITLE
Bootstrap requires jquery + html error

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
               <li>
                 <form class="form-inline" role="form">
                   <div class="checkbox">
-                    <label
+                    <label>
                       <input type="checkbox" ng-model="notimestamp">
                       Hide timestamps
                     </label>


### PR DESCRIPTION
Without jquery the menu in the upper right corner will not open.
