### PR TITLE
Correctly set message text

### DIFF
--- a/js/models.js
+++ b/js/models.js
@@ -238,8 +238,8 @@ models.service('models', ['$rootScope', '$filter', function($rootScope, $filter)
         }
 
         var rtext = "";
-        if (content[0] !== undefined) {
-            rtext = content[0].text;
+        for (var i = 0; i < content.length; ++i) {
+            rtext += content[i].text;
         }
 
        return {


### PR DESCRIPTION
There might be multiple parts to each message, e.g. if a plugin colourises some parts of a message (like @torhve's very nice nickname-in-message-text-highlighter script does).

This fixes issues with plugins not detecting content in message parts other than the first.
