### PR TITLE
Make buffer filter more keyboard friendly

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,7 +279,7 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
               <input class="form-control monospace" type="text" id="bufferFilter" ng-model="search" ng-keydown="handleSearchBoxKey($event)" placeholder="Search">
             </form>
           </li>
-          <li class="buffer" ng-class="{'active': content.active, 'indent': content.indent }" ng-repeat="(key, content) in buffers | toArray | filter:{fullName:search} | filter:hasUnread | orderBy:predicate">
+          <li class="buffer" ng-class="{'active': content.active, 'indent': content.indent }" ng-repeat="(key, content) in (filteredBuffers = (buffers | toArray | filter:{fullName:search} | filter:hasUnread | orderBy:predicate))">
             <a href="#" ng-click="setActiveBuffer(content.id)" title="{{ content.fullName }}">
               <span class="badge pull-right" ng-hide="content.notification" ng-if="content.unread" ng-bind="content.unread"></span>
               <span class="badge pull-right danger" ng-show="content.notification" ng-bind="content.notification"></span>

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -856,7 +856,9 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         } // Handle enter
         else if (code === 13) {
             $event.preventDefault();
-            // TODO Switch to first matching buffer and reset query
+            if ($scope.filteredBuffers.length > 0) {
+                models.setActiveBuffer($scope.filteredBuffers[0].id);
+            }
             $scope.search = '';
         }
     };


### PR DESCRIPTION
This PR allows jumping to the first result of the filtered buffer list by pressing enter. I've also changed the shortcut to focus the buffer filter to alt-g which is more consistent with the other shortcuts and matches [go.py](http://weechat.org/scripts/source/go.py.html/)'s default.
