### PR TITLE
Fix "Switch to buffer with activity" skipping buffers with notifications

### DIFF
--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -832,7 +832,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
             buffer = sortedBuffers[i];
             if (buffer.notification > 0) {
                 $scope.setActiveBuffer(buffer.id);
-                break;
+                return;  // return instead of break so that the second for loop isn't executed
             }
         }
         // No notifications, find first buffer with unread lines instead
@@ -840,7 +840,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
             buffer = sortedBuffers[i];
             if (buffer.unread > 0) {
                 $scope.setActiveBuffer(buffer.id);
-                break;
+                return;
             }
         }
     };


### PR DESCRIPTION
This caused two buffer switches in a row, in effect forgetting the notifications
