### PR TITLE
Install Firefox Webapp from local checkout

### DIFF
--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -788,7 +788,10 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     };
     $scope.install = function() {
         if (navigator.mozApps !== undefined) {
-            var request = navigator.mozApps.install('http://torhve.github.io/glowing-bear/manifest.webapp');
+            // Find absolute url with trailing '/' or '/index.html' removed
+            var base_url = location.protocol + '//' + location.host +
+                location.pathname.replace(/\/(index\.html)?$/, '');
+            var request = navigator.mozApps.install(base_url + '/manifest.webapp');
             request.onsuccess = function () {
                 $scope.isinstalled = true;
                 // Save the App object that is returned


### PR DESCRIPTION
Ask Firefox to install the currently running copy of glowing bear instead of the copy from torhve.github.io

This also fixes a bug when glowing bear is not running from a subdirectory (or one other than /glowing-bear) which would lead to a 404 because of torhve.github.io/original_subdir being loaded instead of /glowing-bear.

Note that installing to a different subdirectory than /glowing-bear will lead to the icons not being found due to the fact that all icon paths inside manifest.webapp [have to be absolute](https://developer.mozilla.org/en-US/Apps/Developing/Manifest#icons).

I can't think of a generic solution for the latter other than maybe using a `.htaccess` rule like

```
RewriteRule ^glowing-bear/(.*) $1
```

but that's of course also highly dependent on the user's setup.
