### PR TITLE
Remove margin-right from #topbar.actions

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -151,7 +151,7 @@ input[type=text], input[type=password], .badge {
 #topbar .actions {
     margin-left: 5px;
     padding-left: 5px;
-    margin-right: 5px;
+    margin-right: 0;
     padding-right: 5px;
     padding-top: 2px;
     height: 35px;


### PR DESCRIPTION
If this is nonzero, content from div.title can overflow into the right margin of the buttons.

![Example](https://dump.tribut.de/button-margin.png)
