### PR TITLE
Treat messages arriving in active buffer as unread if window isn't in focus

### DIFF
--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -683,6 +683,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         // this reinitialze just breaks the bufferlist upon reconnection.
         // Disabled it until it's fully investigated and fixed
         //models.reinitialize();
+        $rootScope.$emit('notificationChanged');
     });
 
     $scope.showSidebar = true;


### PR DESCRIPTION
If messages arrive while the glowing-bear is in the background*, treat the incoming messages as unread. Mark as read when switching back to our tab.
- this API may not be entirely accurate, for example it can't detect an active tab fully hidden behind a non-browser window. It is guaranteed to never claim the window is hidden when it isn't, though, so we're good.
