### PR TITLE
Display all parts of message prefix in notification

### DIFF
--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -856,7 +856,11 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
             body = message.text;
         } else {
             title = 'Highlight in ';
-            body = '<' + message.prefix[0].text + '> ' + message.text;
+            var prefix = '';
+            for (var i = 0; i < message.prefix.length; i++) {
+                prefix += message.prefix[i].text;
+            }
+            body = '<' + prefix + '> ' + message.text;
         }
         title += buffer.shortName;
         title += buffer.fullName.replace(/irc.([^\.]+)\..+/, " ($1)");


### PR DESCRIPTION
Previously, we only got the first part -- which would be "@" for an op, and not their nick.
