### PR TITLE
Try to fetch all unread lines if that is a reasonable amount

### DIFF
--- a/js/models.js
+++ b/js/models.js
@@ -419,11 +419,13 @@ models.service('models', ['$rootScope', '$filter', function($rootScope, $filter)
             previousBuffer.lastSeen = previousBuffer.lines.length-1;
         }
 
+        var unreadSum = activeBuffer.unread + activeBuffer.notification;
+
         activeBuffer.active = true;
         activeBuffer.unread = 0;
         activeBuffer.notification = 0;
 
-        $rootScope.$emit('activeBufferChanged');
+        $rootScope.$emit('activeBufferChanged', unreadSum);
         $rootScope.$emit('notificationChanged');
         return true;
     };


### PR DESCRIPTION
Partially fixes #139 in that it tries to accomplish this, but until we can request
only filtered lines from WeeChat, the best thing we can do is guessing.

**Need feedback** do you want to leave this as is, or maybe try to load more if the amount we got didn't suffice? Or should we wait for the WeeChat relay protocol to support sending only the displayed lines? 
