### PR TITLE
respect notimestamp setting on mobile

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -334,7 +334,7 @@ img.embed {
 
 
 table.notimestamp td.time {
-    display: none;
+    display: none !important;
 }
 
 .modal ul {


### PR DESCRIPTION
marking the display: none as important gives it priority over
the display:inline for td.time on mobile
