### PR TITLE
Fix bug where no (more) lines were loaded despite there being more

### DIFF
--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -455,10 +455,6 @@ function($rootScope,
                 // the read marker position correct
                 buffer.lastSeen -= oldLength;
             }
-            // We request more lines, but didn't get more. No more lines!
-            if (oldLength === buffer.lines.length) {
-                buffer.allLinesFetched  = true;
-            }
             // We requested more lines than we got, no more lines.
             if (linesReceivedCount < numLines) {
                 buffer.allLinesFetched = true;


### PR DESCRIPTION
@torhve, you introduced this check in ad68e32c0826031bf6297b05c57fd4d3e92794b1 and I'm wondering if there is a legitimate case that is caught by the first condition but not the second one.
