### PR TITLE
Improve mobile readability by putting whitespace between messages, not lines

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -374,7 +374,10 @@ h2 span, h2 small {
     }
 
     .bufferline {
-        line-height: 25px;
+        display: inline-block;
+        padding-top: 4px;
+        padding-bottom: 3px;
+        line-height: 15px;
     }
 
     #sidebar {


### PR DESCRIPTION
This generally removes a lot of whitespace on mobile while still improving readability
In particular, it makes it easier to see which lines belong together

Screenshot: http://4z2.de/tmp/gb-lineheight.png
