### PR TITLE
Fix that bug where only one line was loaded

### DIFF
--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -892,7 +892,11 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
 
     // Calculate number of lines to fetch
     $scope.calculateNumLines = function() {
-        var lineHeight = document.querySelector(".bufferline").clientHeight;
+        var bufferlineElements = document.querySelectorAll(".bufferline");
+        var lineHeight = 0, idx = 0;
+        while (lineHeight === 0 && idx < bufferlineElements.length) {
+            lineHeight = bufferlineElements[idx++].clientHeight;
+        }
         var areaHeight = document.querySelector("#bufferlines").clientHeight;
         // Fetch 10 lines more than theoretically needed so that scrolling up will correctly trigger the loading of more lines
         // Also, some lines might be hidden, so it's probably better to have a bit of buffer there


### PR DESCRIPTION
Storytime:

For a mysterious reason, under some circumstances, only one line would be fetched in `fetchMoreLines`, but neither `numLines` nor `buffer.requestedLines` were `undefined`. The paramater `numLines` must have had some strange value, though. `connection.fetchMoreLines` is invoked through the main controllers `$scope.fetchMoreLines`, which sets the parameter to `$scope.lines` if it was undefined before. That value is computed in `$scope.calculateNumLines`, which takes the height of the lines area and divides it by the height of the first
bufferline. This computation is retriggered on every `resize` event. The first bufferline is the 'fetch more lines' link at the top of the window. If the currently active buffer doesn't have more lines, it is hidden with `ngHide`, causing its `clientHeight` property to be `0`, and the number of lines to be fetched `$scope.lines = Infinity` (due to a division by zero).

In `connection.fetchMoreLines`, the following request is then made:

``` javascript
"buffer:0x" + buffer.id + "/own_lines/last_line(-" + numLines + ")/data"
```

to which WeeChat responds with one line. Voilà, there's your mess.

So what was needed to trigger the bug was to resize the window while in a buffer that has no "fetch more lines" link at the top any more because all lines were loaded.
