### PR TITLE
Use shades of gray instead of green readmarker. Fixes #212

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -73,9 +73,12 @@ td.message {
     width: 100%;
     padding: 1px 1px 1px 5px;
 }
-hr {
-    margin: 0;
-    border-color: darkgreen;
+#readmarker {
+    margin-top: 5px;
+    margin-bottom: 5px;
+    border-top: 1px solid rgba(255, 255, 255, 0.3);
+    border-bottom: 1px solid #121212;
+    height: 2px;
 }
 .text {
     white-space: pre-wrap;


### PR DESCRIPTION
Also more space above and under it.

![gb-readmarker](https://cloud.githubusercontent.com/assets/366918/2956999/408cb588-da99-11e3-94be-9916e69ecaf1.png)
