### PR TITLE
Set port variable instead of placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
                   <label class="control-label" for="host">WeeChat relay hostname and port number</label>
                   <div class="input-group">
                     <input type="text" class="form-control monospace" id="host" ng-model="host" placeholder="Address">
-                    <input type="text" class="form-control monospace" id="port" ng-model="port" placeholder="9001">
+                    <input type="text" class="form-control monospace" id="port" ng-model="port">
                   </div>
                   <label class="control-label" for="password">WeeChat relay password</label>
                   <input type="password" class="form-control monospace" id="password" ng-model="password" placeholder="Password">

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -519,6 +519,9 @@ function($rootScope,
 
 weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout', '$log', 'models', 'connection', function ($rootScope, $scope, $store, $timeout, $log, models, connection) {
 
+
+    $scope.port = 9001;
+
     // From: http://stackoverflow.com/a/18539624 by StackOverflow user "plantian"
     $rootScope.countWatchers = function () {
         var q = [$rootScope], watchers = 0, scope;


### PR DESCRIPTION
Suggesting a port in the placeholder can be confusing, as it may
lead people to believe that this value will be sent to the server
while in fact it will not be.

Fix #324
