### PR TITLE
Remove duplicate source of truth with buffers.

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
               <input class="form-control monospace" type="text" id="bufferFilter" ng-model="search" ng-keydown="handleSearchBoxKey($event)" placeholder="Search">
             </form>
           </li>
-          <li class="buffer" ng-class="{'active': buffer.active, 'indent': buffer.indent }" ng-repeat="(key, buffer) in (filteredBuffers = (buffers | toArray | filter:{fullName:search} | filter:hasUnread | orderBy:predicate))">
+          <li class="buffer" ng-class="{'active': buffer.active, 'indent': buffer.indent }" ng-repeat="(key, buffer) in (filteredBuffers = (getBuffers() | toArray | filter:{fullName:search} | filter:hasUnread | orderBy:predicate))">
             <a href="#" ng-click="setActiveBuffer(buffer.id)" title="{{ buffer.fullName }}">
               <span class="badge pull-right" ng-class="{'danger': buffer.notification}" ng-if="buffer.notification || buffer.unread" ng-bind="buffer.notification || buffer.unread"></span>
               <span class="buffername">{{ buffer.shortName || buffer.fullName }}</span>

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -774,9 +774,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     });
 
     $rootScope.$on('relayDisconnect', function() {
-        // this reinitialze just breaks the bufferlist upon reconnection.
-        // Disabled it until it's fully investigated and fixed
-        //models.reinitialize();
+        models.reinitialize();
         $rootScope.$emit('notificationChanged');
         $scope.connectbutton = 'Connect';
     });
@@ -784,7 +782,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
 
     $scope.showSidebar = true;
 
-    $scope.buffers = models.model.buffers;
+    $scope.getBuffers = models.getBuffers.bind(models);
 
     $scope.bufferlines = {};
     $scope.nicklist = {};
@@ -1125,7 +1123,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
 
     $rootScope.switchToActivityBuffer = function() {
         // Find next buffer with activity and switch to it
-        var sortedBuffers = _.sortBy($scope.buffers, 'number');
+        var sortedBuffers = _.sortBy($scope.getBuffers(), 'number');
         var i, buffer;
         // Try to find buffer with notification
         for (i in sortedBuffers) {


### PR DESCRIPTION
This fixes #73 and is a permanent fix to the bug (#214) that was introduced with #169.

The bug was caused by when `models.reinitialize()` creates a new empty object to `models.model.buffers`, `$scope.buffers` does not get the new object reference which causes a duplicate source of truth with the `$scope` object containing the outdated data. This fix makes the `$scope` attribute a reference to the `models.getBuffers` method. I renamed the `$scope` attribute from `buffers` to `getBuffers` in order to distinguish that it is associated with that method and not the property.
