### PR TITLE
Focus input bar after pressing the send button

### DIFF
--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -1312,6 +1312,8 @@ weechat.directive('inputBar', function() {
                     // Empty the input after it's sent
                     $scope.command = '';
                 }
+
+                $scope.getInputNode().focus();
             };
 
             $rootScope.addMention = function(prefix) {


### PR DESCRIPTION
This prevents the keyboard from closing on mobile
