### PR TITLE
localstorage: fix initial value setting

### DIFF
--- a/js/localstorage.js
+++ b/js/localstorage.js
@@ -1,3 +1,4 @@
+'use strict';
 
 var ls = angular.module('localStorage',[]);
 
@@ -97,8 +98,10 @@ ls.factory("$store",function($parse){
              * @returns {*} - returns whatever the stored value is
              */
             bind: function ($scope, key, def) {
-                def = def || '';
-                if (publicMethods.get(key) === undefined) {
+                if (def === undefined) {
+                    def = '';
+                }
+                if (publicMethods.get(key) === undefined || publicMethods.get(key) === null) {
                     publicMethods.set(key, def);
                 }
                 $parse(key).assign($scope, publicMethods.get(key));


### PR DESCRIPTION
Looks like localStorage returns null instead of undefined in some cases, this will fix so that our default settings will work again, not only our default settings that were negative :-)
