### PR TITLE
localstorage: fix initial value setting

### DIFF
--- a/js/localstorage.js
+++ b/js/localstorage.js
@@ -1,3 +1,4 @@
+(function() {
 'use strict';
 
 var ls = angular.module('localStorage',[]);
@@ -113,3 +114,4 @@ ls.factory("$store",function($parse){
     };
     return publicMethods;
 });
+})();


### PR DESCRIPTION
To quote @torhve: "Looks like localStorage returns null instead of undefined in some cases, this will fix so that our default settings will work again, not only our default settings that were negative :-)"
