### PR TITLE
Change order of default monospace fonts, remove Terminus

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -254,7 +254,7 @@ input[type=text], input[type=password], #sendMessage, .badge {
 }
 
 .monospace {
-    font-family: 'Terminus', 'Consolas', 'Monaco', 'Inconsolata', 'Ubuntu Mono', monospace;
+    font-family: 'Inconsolata', 'Consolas', 'Monaco', 'Ubuntu Mono', monospace;
 }
 
 #bufferlines {


### PR DESCRIPTION
Having a bitmap font as first choice is really stupid, as noted by @Evropi in #322 (this fixes #322)

As Inconsolata is a wonderful font that has the advantages of a monospace font combined with a level of readability that is otherwise reserved to sans-serif fonts, I think it should be first in the list.
