### PR TITLE
Fix rendering of settings dialog on mobile

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -470,6 +470,10 @@ h2 span, h2 small {
     }
 }
 
+.make-thinner {
+    padding-right: -15px;
+}
+
 /* */
 /* Mobile layout */
 /* */

--- a/index.html
+++ b/index.html
@@ -285,8 +285,8 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
               <li id="fontchoice">
                 <form class="form-horizontal" role="form">
                   <div class="form-group">
-                    <label for="font" class="col-sm-3 control-label">Preferred font</label>
-                    <div class="col-sm-4" style="padding-left: 0;">
+                    <label for="font" class="col-sm-3 control-label make-thinner">Preferred font</label>
+                    <div class="col-sm-4">
                       <input type="text" ng-model="fontfamily" class="form-control" id="font">
                     </div>
 


### PR DESCRIPTION
That `padding-left: 0` caused awkward misalignment on mobile
