### PR TITLE
Properly iterate over modals in ESC key handler

### DIFF
--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -1533,7 +1533,7 @@ weechat.directive('inputBar', function() {
 
                     // Check if a modal is visible. If so, close it instead of disconnecting
                     var modals = document.querySelectorAll('.gb-modal');
-                    for (var modalId in modals) {
+                    for (var modalId = 0; modalId < modals.length; modalId++) {
                         if (modals[modalId].getAttribute('data-state') === 'visible') {
                             modals[modalId].setAttribute('data-state', 'hidden');
                             return true;


### PR DESCRIPTION
the old way included attributes like 'length' and would raise an
exception, causing disconnection via double-esc to fail
