### PR TITLE
Fix for iOS status bar not being visible due to black background

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <title ng-bind-template="{{ notificationStatus }}Glowing Bear {{ pageTitle}}"></title>
     <link href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet" media="screen">
     <link rel="shortcut icon" sizes="128x128" href="assets/img/glowing_bear_128x128.png">


### PR DESCRIPTION
Adds a meta tag to have the top status bar in iOS render with white text rather than black text when running as a web clip.

Before on left, after on right.

![gb_diff](https://cloud.githubusercontent.com/assets/176014/3787198/977ad0ac-1a07-11e4-998f-a2d16aed727c.png)
