### PR TITLE
Add indicators to the accordion so people will notice it's actually there

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -481,6 +481,18 @@ h2 span, h2 small {
 .panel[data-state=collapsed] {
     border: 0px solid transparent;
 }
+.panel .panel-title:before {
+    display: inline-block;
+    font-size: 22px;
+    line-height: 20px;
+    margin: -3px 5px -3px 0;
+}
+.panel[data-state=active] .panel-title:before {
+    content: "–";
+}
+.panel[data-state=collapsed] .panel-title:before {
+    content: "+";
+}
 
 /* fix for firefox being stupid */
 @-moz-document url-prefix() {


### PR DESCRIPTION
The current design isn't very intuitive, many people don't realise that they can click those boxes. Add folding indicators to make it more obvious.

![](https://4z2.de/gb-accordion-indicator.png)
