### PR TITLE
Fix word breaking

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -56,11 +56,21 @@ td.prefix {
     border-right: 1px solid #444;
 }
 td.message {
-    word-wrap: break-word;
-    word-break: break-word;
     vertical-align: top;
     width: 100%;
     padding: 1px 1px 1px 5px;
+
+-ms-word-break: break-all;
+    word-break: break-all;
+
+    /* Non standard for webkit */
+    word-break: break-word;
+
+-webkit-hyphens: auto;
+   -moz-hyphens: auto;
+    -ms-hyphens: auto;
+        hyphens: auto;
+
 }
 #readmarker {
     margin-top: 5px;

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
     <script type="text/javascript" src="3rdparty/bindonce.min.js"></script>
     <script type="text/javascript" src="3rdparty/favico-0.3.4-mod.min.js"></script>
   </head>
-  <body ng-controller="WeechatCtrl" ng-keydown="handleKeyPress($event)" ng-class="{'no-overflow': connected}">
+  <body ng-controller="WeechatCtrl" ng-keydown="handleKeyPress($event)" ng-class="{'no-overflow': connected}" lang="en-US">
     <div ng-hide="connected" class="container">
       <h2>
         <img alt="logo" src="assets/img/glowing-bear.svg">


### PR DESCRIPTION
Use break-all to force breaking in all browsers.

Following best practices from: http://kenneth.io/blog/2012/03/04/word-wrapping-hypernation-using-css/
