### PR TITLE
Use "off" glyphicon instead of "remove"

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -118,6 +118,10 @@ input[type=text], input[type=password], #sendMessage, .badge {
 .glyphicon {
     top: 0; /* Fixes alignment issue in top bar */
 }
+.glyphicon-off {
+    top: 1px; /* Fixes for relative glyphicon size */
+    font-size: 28px;
+}
 #topbar {
     position: fixed;
     width: 100%;
@@ -220,7 +224,7 @@ input[type=text], input[type=password], #sendMessage, .badge {
     overflow-x: hidden;
     right: 0;
     top: 0;
-    padding-top: 35px; 
+    padding-top: 35px;
     padding-left: 5px;
     padding-bottom: 35px;
     z-index: 2;

--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
             </a>
           </div>
           <a ng-click="disconnect()" title="Disconnect from WeeChat">
-            <i class="glyphicon glyphicon-remove"></i>
+            <i class="glyphicon glyphicon-off"></i>
           </a>
         </div>
       </div>


### PR DESCRIPTION
Needs a few fixes to not look disproportionately large next to the cog.
Also remove that sodden trailing space.

Supercedes #410 
