### PR TITLE
Prevent triggering ng-focus on input during completion

### DIFF
--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -1428,8 +1428,10 @@ weechat.directive('inputBar', function() {
                 $scope.command = nickComp.text;
 
                 // update current caret position
-                inputNode.focus();
-                inputNode.setSelectionRange(nickComp.caretPos, nickComp.caretPos);
+                setTimeout(function() {
+                    inputNode.focus();
+                    inputNode.setSelectionRange(nickComp.caretPos, nickComp.caretPos);
+                }, 0);
             };
 
 


### PR DESCRIPTION
$apply during another $apply is not possible, and .focus() on the input node triggers the ng-focus on it (which hides the sidebar, if on mobile), so to prevent the exception from being thrown, move the input node focusing out of the $apply with a timeout of 0.
