### PR TITLE
Provide a way to manage different themes in Glowing Bear

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -384,10 +384,11 @@ table.notimestampseconds td.time span.seconds {
     border-bottom: 0;
 }
 
-#fontchoice label {
+.standard-labels label {
     font-weight: normal;
     text-align: left;
 }
+
 
 h2 {
     padding-bottom: 5px;

--- a/css/themes/dark.css
+++ b/css/themes/dark.css
@@ -48,7 +48,7 @@ li.notification {
     background-color:rgba(0, 0, 0, 0.5)
 }
 
-input[type=text], input[type=password], #sendMessage, .badge {
+select.form-control, select option, input[type=text], input[type=password], #sendMessage, .badge {
     color: #ccc;
     box-shadow: 0px 1px 0px rgba(255, 255, 255, 0.1), 0px 1px 7px 0px rgba(0, 0, 0, 0.8) inset;
     background: none repeat scroll 0% 0% rgba(0, 0, 0, 0.3);

--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
     <link rel="apple-touch-icon" sizes="128x128" href="assets/img/glowing_bear_128x128.png">
     <link rel="shortcut icon" type="image/png" href="assets/img/favicon.png" >
     <link href="css/glowingbear.css" rel="stylesheet" media="screen">
-    <link href="css/themes/dark.css" rel="stylesheet" media="screen">
     <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0-beta.19/angular.min.js"></script>
     <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0-beta.19/angular-route.min.js"></script>
     <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0-beta.19/angular-sanitize.min.js"></script>
@@ -37,6 +36,7 @@
     <script type="text/javascript" src="3rdparty/favico-0.3.4-mod.min.js"></script>
   </head>
   <body ng-controller="WeechatCtrl" ng-keydown="handleKeyPress($event)" ng-keypress="handleKeyPress($event)" ng-class="{'no-overflow': connected}" lang="en-US">
+    <link ng-href="css/themes/{{theme}}.css" rel="stylesheet" media="screen" />
     <div ng-hide="connected" class="container">
       <h2>
         <img alt="logo" src="assets/img/glowing-bear.svg">
@@ -295,7 +295,7 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
           </div>
           <div class="modal-body">
             <ul class="">
-              <li id="fontchoice">
+              <li class="standard-labels">
                 <form class="form-horizontal" role="form">
                   <div class="form-group">
                     <label for="font" class="col-sm-3 control-label make-thinner">Preferred font</label>
@@ -310,6 +310,17 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
                   </div>
                 </form>
               </li>
+              <li class="standard-labels">
+                <form class="form-horizontal" role="form">
+                  <div class="form-group">
+                    <label for="theme" class="col-sm-3 control-label make-thinner">Theme</label>
+                    <div class="col-sm-7">
+                      <select id="theme" class="form-control" ng-model="theme" ng-options="theme for theme in themes"></select>
+                    </div>
+                  </div>
+                </form>
+              </li>
+
               <li>
                 <form class="form-inline" role="form">
                   <div class="checkbox">

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -2,7 +2,9 @@ var weechat = angular.module('weechat', ['ngRoute', 'localStorage', 'weechatMode
 
 weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout', '$log', 'models', 'connection', 'notifications', 'utils', function ($rootScope, $scope, $store, $timeout, $log, models, connection, notifications, utils) {
 
+
     $scope.command = '';
+    $scope.themes = ['dark'];
 
     // From: http://stackoverflow.com/a/18539624 by StackOverflow user "plantian"
     $rootScope.countWatchers = function () {
@@ -253,6 +255,8 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     $store.bind($scope, "soundnotification", false);
     // Save setting for font family
     $store.bind($scope, "fontfamily");
+    // Save setting for theme
+    $store.bind($scope, "theme", 'dark');
     // Save setting for font size
     $store.bind($scope, "fontsize", "14px");
     // Save setting for readline keybindings


### PR DESCRIPTION
- The only theme we have right now is ther dark theme
- The dark theme may be hard to use on mobile. In that regard, we have received requests for a light theme.
- This PR provides a way to make it easier for users to create their own theme for GB.
