### PR TITLE
Fix Alt+[0-9] buffer access order

### DIFF
--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -1529,9 +1529,19 @@ weechat.directive('inputBar', function() {
                     }
 
                     var bufferNumber = code - 48 - 1 ;
-                    var activeBufferId = Object.keys(models.getBuffers())[bufferNumber];
+                    // Map the buffers to only their numbers and IDs so we don't have to
+                    // copy the entire (possibly very large) buffer object, and then sort
+                    // the buffers according to their WeeChat number
+                    var sortedBuffers = _.map(models.getBuffers(), function(buffer) {
+                        return [buffer.number, buffer.id];
+                    }).sort(function(left, right) {
+                        // By default, Array.prototype.sort() sorts alphabetically.
+                        // Pass an ordering function to sort by first element.
+                        return left[0] - right[0];
+                    });
+                    var activeBufferId = sortedBuffers[bufferNumber];
                     if (activeBufferId) {
-                        models.setActiveBuffer(activeBufferId);
+                        models.setActiveBuffer(activeBufferId[1]);
                         $event.preventDefault();
                     }
                 }


### PR DESCRIPTION
WeeChat sends them in no particular order, we need to sort the buffers by
their WeeChat number. To avoid copying the potentially very large buffer
objects around needlessly, extract the relevant keys and sort, then access.

This is based on https://github.com/ailin-nemui/glowing-bear/commit/ad50220bfdfcf029fc47093ce5cfea04bf90fe79
