### PR TITLE
fixup font-family and font-size setting glitches

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,7 +305,7 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
 
                     <label for="size" class="col-sm-1 control-label">Size</label>
                     <div class="col-sm-2">
-                      <input type="text" ng-model="fontsize" class="form-control" id="size" placeholder="14px">
+                      <input type="text" ng-model="fontsize" class="form-control" id="size">
                     </div>
                   </div>
                 </form>

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -248,9 +248,9 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     // Save setting for playing sound on notification
     $store.bind($scope, "soundnotification", false);
     // Save setting for font family
-    $store.bind($scope, "fontfamily", utils.getClassStyle('favorite-font', 'fontFamily'));
+    $store.bind($scope, "fontfamily");
     // Save setting for font size
-    $store.bind($scope, "fontsize", utils.getClassStyle('favorite-font', 'fontSize'));
+    $store.bind($scope, "fontsize", "14px");
     // Save setting for readline keybindings
     $store.bind($scope, "readlineBindings", false);
 


### PR DESCRIPTION
Replace fontSize placeholder by default value. Placeholders should be used
as suggestions, not effective values.

Remove spurious default value for fontFamily (it is defined right below)
