### PR TITLE
Fix plugin selectors after angular upgrade

### DIFF
--- a/directives/plugin.html
+++ b/directives/plugin.html
@@ -4,7 +4,7 @@
     Hide {{ ::plugin.name }}
   </button>
 
-  <div ng-bind-html="displayedContent" class="embed" ng-class="::('embed_' + plugin.$$hashKey)"></div>
+  <div ng-bind-html="displayedContent" class="embed" ng-class="::plugin.className"></div>
 </div>
 
 <div ng-hide="plugin.visible">

--- a/js/plugin-directive.js
+++ b/js/plugin-directive.js
@@ -21,6 +21,13 @@ weechat.directive('plugin', ['$rootScope', function($rootScope) {
 
             $scope.plugin.visible = $rootScope.auto_display_embedded_content;
 
+            // user-accessible hash key that is a valid CSS class name
+            $scope.plugin.className = "embed_" + $scope.plugin.$$hashKey.replace(':','_');
+
+            $scope.plugin.getElement = function() {
+                return document.querySelector("." + $scope.plugin.className);
+            };
+
             $scope.hideContent = function() {
                 $scope.plugin.visible = false;
             };
@@ -33,7 +40,7 @@ weechat.directive('plugin', ['$rootScope', function($rootScope) {
                  * content is shown.
                  */
 
-                 var embed = document.querySelector(".embed_" + $scope.plugin.$$hashKey);
+                var embed = $scope.plugin.getElement();
 
                 // If the plugin is asynchronous / lazy, execute it now and let it insert itself
                 // TODO store the result between channel switches

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -348,7 +348,7 @@ plugins.factory('userPlugins', function() {
                 url = match[0] + '.json';
                 // load gist asynchronously -- return a function here
                 return function() {
-                    var element = document.querySelector('.embed_' + this.$$hashKey);
+                    var element = this.getElement();
                     jsonp(url, function(data) {
                         // Add the gist stylesheet only once
                         if (document.querySelectorAll('link[rel=stylesheet][href="' + data.stylesheet + '"]').length < 1) {
@@ -370,7 +370,7 @@ plugins.factory('userPlugins', function() {
             if (match) {
                 url = 'https://api.twitter.com/1/statuses/oembed.json?id=' + match[2];
                 return function() {
-                    var element = document.querySelector('.embed_' + this.$$hashKey);
+                    var element = this.getElement();
                     jsonp(url, function(data) {
                         // sepearate the HTML into content and script tag
                         var scriptIndex = data.html.indexOf("<script ");


### PR DESCRIPTION
The recent angular update changed the format of the hash keys.
They're now in the format 'object:123' (etc), which isn't a valid
CSS class name any more, but we used the $$hashKey as such.

I used this opportunity to introduce a bit of abstraction there as well
