### PR TITLE
Scripting the port numbers in help, adding password reminder

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,6 +164,7 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
 </pre>
               <p>If WeeChat is already running, you can reload the certificate and private key and set up an encrypted relay on port {{ port || 8000 }} with these WeeChat commands:</p>
 <pre>
+/set relay.network.password yourpassword
 /relay sslcertkey
 /relay add ssl.weechat {{ port || 8000 }}
 </pre>


### PR DESCRIPTION
The "Encryption instructions" in the landing page help is now scripted to display commands using the given port from "Connection settings" just like hostname is used in the cert generation command.

I also added a reminder about setting a password in the Encryption instructions. It's easy to forget when following a step-by-step instruction.

These changes only affect the help text on the landing page, and should be quite uncontroversial.
