### PR TITLE
[WIP] Start implementing auto-reconnect

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -267,11 +267,13 @@ td.time {
     top: 35px;
     position: fixed;
     z-index: 9999;
-    background-color: #eee;
-    color: #333;
-    width: 100%;
+    width: 80%;
     margin: 0;
     padding: 5px;
+    left: 10%;
+}
+#reconnect a {
+    color: white;
 }
 
 .footer {

--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -263,6 +263,17 @@ td.time {
     font-family: sans-serif;
 }
 
+#reconnect {
+    top: 35px;
+    position: fixed;
+    z-index: 9999;
+    background-color: #eee;
+    color: #333;
+    width: 100%;
+    margin: 0;
+    padding: 5px;
+}
+
 .footer {
     position: fixed;
     bottom: 0;

--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -320,6 +320,10 @@ div.embed img.embed {
     max-width: 100%;
 }
 
+video.embed {
+    max-width: 100%;
+}
+
 div.colourbox {
     display: inline-block;
     border-radius: 3px;

--- a/directives/input.html
+++ b/directives/input.html
@@ -1,6 +1,6 @@
 <form class="form form-horizontal" id="inputform" ng-submit="sendMessage()">
   <div class="input-group">
-    <textarea id="{{inputId}}" class="form-control favorite-font" ng-trim="false" rows="1" autocomplete="off" ng-model="command" ng-focus="hideSidebar()">
+    <textarea id="{{inputId}}" class="form-control favorite-font" ng-trim="false" rows="1" autocomplete="on" ng-model="command" ng-focus="hideSidebar()">
     </textarea>
     <span class="input-group-btn">
       <button class="btn btn-default btn-primary unselectable">Send</button>

--- a/index.html
+++ b/index.html
@@ -289,15 +289,17 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
             </tr>
           </tbody>
         </table><span id="end-of-buffer"></span>
-        <div id="reconnect" ng-if="reconnecting">
-          <i class="glyphicon glyphicon-refresh"></i> Reconnecting... <a ng-click="reconnect()">Try now</a>
-        </div>
       </div>
       <div class="footer" ng-class="{'withnicklist': showNicklist}">
         <div input-bar input-id="sendMessage" command="command"></div>
       </div>
     </div>
     <div id="soundNotification"></div>
+    <div id="reconnect" class="alert alert-danger" ng-click="reconnect()" ng-show="reconnecting">
+        <p><strong>Connection to WeeChat lost</strong></p>
+        <i class="glyphicon glyphicon-refresh"></i>
+        Reconnecting... <a class="btn btn-tiny" ng-click="reconnect()">Click to try to reconnect now</a>
+    </div>
     <div id="settingsModal" class="gb-modal" data-state="hidden">
       <div class="backdrop" ng-click="closeModal($event)"></div>
       <div class="modal-dialog">

--- a/index.html
+++ b/index.html
@@ -240,7 +240,7 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
         <ul class="nav nav-pills nav-stacked" ng-class="{'indented': (predicate === 'serverSortKey'), 'showquickkeys': showQuickKeys}">
           <li class="bufferfilter">
             <form role="form">
-              <input class="form-control favorite-font" type="text" id="bufferFilter" ng-model="search" ng-keydown="handleSearchBoxKey($event)" placeholder="Search">
+              <input class="form-control favorite-font" type="text" id="bufferFilter" ng-model="search" ng-keydown="handleSearchBoxKey($event)" placeholder="Search" autocomplete="off">
             </form>
           </li>
           <li class="buffer" ng-class="{'active': buffer.active, 'indent': buffer.indent, 'channel': buffer.type === 'channel', 'channel_hash': buffer.prefix === '#', 'channel_plus': buffer.prefix === '+', 'channel_ampersand': buffer.prefix === '&', 'private': buffer.type === 'private'}" ng-repeat="(key, buffer) in (filteredBuffers = (getBuffers() | toArray:'withidx' | filter:{fullName:search} | filter:hasUnread | orderBy:predicate | getBufferQuickKeys:this))">

--- a/index.html
+++ b/index.html
@@ -285,6 +285,9 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
             </tr>
           </tbody>
         </table><span id="end-of-buffer"></span>
+        <div id="reconnect" ng-if="reconnecting">
+          <i class="glyphicon glyphicon-refresh"></i> Reconnecting... <a ng-click="reconnect()">Try now</a>
+        </div>
       </div>
       <div class="footer" ng-class="{'withnicklist': showNicklist}">
         <div input-bar input-id="sendMessage" command="command"></div>

--- a/index.html
+++ b/index.html
@@ -14,10 +14,10 @@
     <link rel="apple-touch-icon" sizes="128x128" href="assets/img/glowing_bear_128x128.png">
     <link rel="shortcut icon" type="image/png" href="assets/img/favicon.png" >
     <link href="css/glowingbear.css" rel="stylesheet" media="screen">
-    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.9/angular.min.js"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.9/angular-route.min.js"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.9/angular-sanitize.min.js"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.9/angular-touch.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.14/angular.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.14/angular-route.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.14/angular-sanitize.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.14/angular-touch.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.7.0/underscore-min.js"></script>
     <script src="//twemoji.maxcdn.com/twemoji.min.js"></script>
     <script type="text/javascript" src="3rdparty/inflate.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -275,7 +275,7 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
               <td class="prefix"><a ng-click="addMention(bufferline.prefix)"><span ng-repeat="part in ::bufferline.prefix" ng-class="::part.classes" ng-bind="::part.text"></span></a></td><!--
            --><td class="message"><!--
              --><div ng-repeat="metadata in ::bufferline.metadata" plugin data="::metadata"></div><!--
-             --><span ng-repeat="part in ::bufferline.content" class="text" ng-class="::part.classes" ng-bind-html="::part.text | linky:'_blank' | DOMfilter:'irclinky' | DOMfilter:'emojify':enableJSEmoji | DOMfilter:'inlinecolour' "></span>
+             --><span ng-repeat="part in ::bufferline.content" class="text" ng-class="::part.classes" ng-bind-html="::part.text | linky:'_blank' | DOMfilter:'irclinky' | DOMfilter:'emojify':settings.enableJSEmoji | DOMfilter:'inlinecolour' "></span>
               </td>
             </tr>
             <tr class="readmarker" ng-if="activeBuffer().lastSeen==$index">
@@ -437,7 +437,7 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
                 <form class="form-inline" role="form">
                   <div class="checkbox">
                     <label>
-                      <input type="checkbox" ng-model="enableJSEmoji">
+                      <input type="checkbox" ng-model="settings.enableJSEmoji">
                       Enable non-native Emoji support <span class="text-muted settings-help">Displays Emoji characters as images</span>
                     </label>
                   </div>

--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
           <div id="collapseThree" class="panel-collapse collapse in">
             <div class="panel-body">
               <p>If you check the encryption box, the communication between browser and WeeChat will be encrypted with TLS.</p>
-              <p><strong>Note</strong>: If you are using a self-signed certificate, you have to visit <a href="https://{{ settings.host }}:{{ settings.port }}/">https://{{ settings.host || 'weechathost' }}:{{ settings.port || 'relayport' }}/</a> in your browser first to add a security exception. You can close that tab once you confirmed the certificate, no content will appear. The necessity of this process is a bug in <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=594502">Firefox</a> and other browsers.</p>
+              <p><strong>Note</strong>: If you are using a self-signed certificate, you have to visit <a href="https://{{ settings.host }}:{{ settings.port }}/weechat">https://{{ settings.host || 'weechathost' }}:{{ settings.port || 'relayport' }}/weechat</a> in your browser first to add a security exception. You can close that tab once you confirmed the certificate, no content will appear. The necessity of this process is a bug in <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=594502">Firefox</a> and other browsers.</p>
               <p><strong>Setup</strong>: If you want to use an encrypted session you first have to set up the relay to use TLS. You basically have two options: a self-signed certificate is easier to set up, but requires manual security exceptions. Using a certificate that is trusted by your browser requires more setup, but offers greater convenience later on and does not require security exceptions. You can find a guide to set up WeeChat with a free trusted certificate from StartSSL <a href="https://4z2.de/2014/07/06/weechat-trusted-relay">here</a>. Should you wish to use a self-signed certificate instead, execute the following commands in a shell on the same host and as the user running WeeChat:</p>
 <pre>
 $ mkdir -p ~/.weechat/ssl
@@ -185,11 +185,15 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
           <div id="collapseFour" class="panel-collapse collapse in">
             <div class="panel-body">
               <p>You don't need to install anything to use this app, it should work with any modern browser. Start using it <a data-toggle="collapse" data-parent="#accordion" href="#collapseOne">right now</a>! However, there are a few ways to improve integration with your operating system.</p>
-              <h3>Firefox</h3>
-              <p>If you have a recent version of Firefox you can install glowing bear as an app. Click the button to install.</p>
-              <button class="btn btn-lg btn-primary" ng-click="install()">Install Firefox app <i class="glyphicon glyphicon-chevron-right"></i></button>
+              <h3>Mobile Applications</h3>
+              <p>If you're running Android 4.4 or later, you can install our app from the Google Play Store! We also provide an optimized application for Firefox OS devices. If you're using the Firefox browser, keep on reading below -- the Firefox OS app won't work for you</p>
+              <p><a href="https://play.google.com/store/apps/details?id=com.glowing_bear"><img alt="Android app on Google Play" src="https://developer.android.com/images/brand/en_app_rgb_wo_45.png" /></a> <a href="https://marketplace.firefox.com/app/glowing-bear/"><img alt="Firefox OS app in the Firefox Marketplace" src="https://marketplace.cdn.mozilla.net/media/img/mkt/badges/firefox-marketplace_badge-orange_129_45.png" /></a></p>
+              <h3>Firefox Browser</h3>
+              <p>If you have a recent version of Firefox you can install Glowing Bear as a Firefox app. Click the button to install.</p>
+              <p><button class="btn btn-lg btn-primary" ng-click="install()">Install Firefox app <i class="glyphicon glyphicon-chevron-right"></i></button></p>
+              <p>Note for self-signed certificates: Firefox does not share a certificate storage with Firefox apps, so accepting self-signed certificates is a bit tricky.</p>
               <h3>Chrome</h3>
-              <p>To install glowing bear as an app in Chrome, select <kbd>Menu - Add to home screen</kbd> (Android) or <kbd>Menu - More tools - Create application shortcuts</kbd> (desktop version).</p>
+              <p>To install Glowing Bear as an app in Chrome for Android, select <kbd>Menu - Add to home screen</kbd>. In the desktop version of Chrome, click <kbd>Menu - More tools - Create application shortcuts</kbd>.</p>
             </div>
           </div>
         </div>

--- a/js/connection.js
+++ b/js/connection.js
@@ -184,10 +184,10 @@ weechat.factory('connection',
         $log.info('Attempting to reconnect...');
         var d = connectionData;
         connect(d[0], d[1], d[2], d[3], d[4], function() {
+            $rootScope.reconnecting = false;
             // on success, update active buffer
             models.setActiveBuffer(bufferId);
             $log.info('Sucessfully reconnected to relay');
-            $rootScope.reconnecting = false;
         }, function() {
             // on failure, schedule another attempt
             if (timeout >= 600000) {
@@ -217,6 +217,8 @@ weechat.factory('connection',
         }
 
         $rootScope.reconnecting = true;
+        // Have to do this to get the reconnect banner to show
+        $rootScope.$apply();
 
         var bufferId = models.getActiveBuffer().id,
             timeout = 3000;  // start with a three-second timeout

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -263,6 +263,8 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
 
     $rootScope.connected = false;
     $rootScope.waseverconnected = false;
+    $rootScope.userdisconnect = false;
+    $rootScope.reconnecting = false;
 
     $rootScope.models = models;
 
@@ -502,6 +504,10 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     $scope.disconnect = function() {
         $scope.connectbutton = 'Connect';
         connection.disconnect();
+    };
+    $scope.reconnect = function() {
+        var bufferId = models.getActiveBuffer().id;
+        connection.attemptReconnect(bufferId, 3000);
     };
 
 //XXX this is a bit out of place here, either move up to the rest of the firefox install code or remove

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -35,7 +35,8 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         'showtimestampSeconds': false,
         'fontsize': '14px',
         'fontfamily': (utils.isMobileUi() ? 'sans-serif' : 'Inconsolata, Consolas, Monaco, Ubuntu Mono, monospace'),
-        'readlineBindings': false
+        'readlineBindings': false,
+        'enableJSEmoji': false
     });
     $scope.settings = settings;
 

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -283,6 +283,15 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         settings.password = '';
     }
 
+    // Check if user decides to save password, and copy it over
+    settings.addCallback('savepassword', function(newvalue) {
+        if (settings.savepassword) {
+            // Init value in settings module
+            settings.setDefaults({'password': $scope.password});
+            settings.password = $scope.password;
+        }
+    });
+
     $rootScope.wasMobileUi = false;
     if (utils.isMobileUi()) {
         $rootScope.wasMobileUi = true;

--- a/js/handlers.js
+++ b/js/handlers.js
@@ -237,6 +237,7 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
         _buffer_line_added: handleBufferLineAdded,
         _buffer_localvar_added: handleBufferLocalvarChanged,
         _buffer_localvar_removed: handleBufferLocalvarChanged,
+        _buffer_localvar_changed: handleBufferLocalvarChanged,
         _buffer_opened: handleBufferOpened,
         _buffer_title_changed: handleBufferTitleChanged,
         _buffer_renamed: handleBufferRenamed,

--- a/js/handlers.js
+++ b/js/handlers.js
@@ -43,6 +43,53 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
         }
     };
 
+    var handleBufferInfo = function(message) {
+        var bufferInfos = message.objects[0].content;
+        // buffers objects
+        for (var i = 0; i < bufferInfos.length ; i++) {
+            var bufferId = bufferInfos[i].pointers[0];
+            var buffer = models.getBuffer(bufferId);
+            if (buffer !== undefined) {
+                // We already know this buffer
+                handleBufferUpdate(buffer, bufferInfos[i]);
+            } else {
+                buffer = new models.Buffer(bufferInfos[i]);
+                models.addBuffer(buffer);
+                // Switch to first buffer on startup
+                if (i === 0) {
+                    models.setActiveBuffer(buffer.id);
+                }
+            }
+        }
+    };
+
+    var handleBufferUpdate = function(buffer, message) {
+        if (message.pointers[0] !== buffer.id) {
+            // this is information about some other buffer!
+            return;
+        }
+
+        // weechat properties -- short name can be changed
+        buffer.shortName = message.short_name;
+        buffer.trimmedName = buffer.shortName.replace(/^[#&+]/, '');
+        buffer.title = message.title;
+        buffer.number = message.number;
+
+        // reset these, hotlist info will arrive shortly
+        buffer.notification = 0;
+        buffer.unread = 0;
+        buffer.lastSeen = -1;
+
+        if (message.local_variables.type !== undefined) {
+            buffer.type = message.local_variables.type;
+            buffer.indent = (['channel', 'private'].indexOf(buffer.type) >= 0);
+        }
+
+        if (message.notify !== undefined) {
+            buffer.notify = message.notify;
+        }
+    };
+
     var handleBufferLineAdded = function(message) {
         message.objects[0].content.forEach(function(l) {
             handleLine(l, false);
@@ -215,7 +262,8 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
         handleEvent: handleEvent,
         handleLineInfo: handleLineInfo,
         handleHotlistInfo: handleHotlistInfo,
-        handleNicklist: handleNicklist
+        handleNicklist: handleNicklist,
+        handleBufferInfo: handleBufferInfo
     };
 
 }]);

--- a/js/models.js
+++ b/js/models.js
@@ -134,6 +134,12 @@ models.service('models', ['$rootScope', '$filter', function($rootScope, $filter)
          */
         var updateNick = function(group, nick) {
             group = nicklist[group];
+            if (group === undefined) {
+                // We are getting nicklist events for a buffer where not yet
+                // have populated the nicklist, so there will be nothing to
+                // update. Just ignore the event.
+                return;
+            }
             for(var i in group.nicks) {
                 if (group.nicks[i].name === nick.name) {
                     group.nicks[i] = nick;

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -268,6 +268,15 @@ plugins.factory('userPlugins', function() {
     });
 
     /*
+     * mp4 video Preview
+     */
+    var videoPlugin = new UrlPlugin('video', function(url) {
+        if (url.match(/\.(mp4|webm|ogv)\b/i)) {
+            return '<video class="embed" width="560"><source src="'+url+'"></source></video>';
+        }
+    });
+
+    /*
      * Cloud Music Embedded Players
      */
     var cloudmusicPlugin = new UrlPlugin('cloud music', function(url) {
@@ -382,7 +391,7 @@ plugins.factory('userPlugins', function() {
     });
 
     return {
-        plugins: [youtubePlugin, dailymotionPlugin, allocinePlugin, imagePlugin, spotifyPlugin, cloudmusicPlugin, googlemapPlugin, asciinemaPlugin, yrPlugin, gistPlugin, tweetPlugin, vinePlugin]
+        plugins: [youtubePlugin, dailymotionPlugin, allocinePlugin, imagePlugin, videoPlugin, spotifyPlugin, cloudmusicPlugin, googlemapPlugin, asciinemaPlugin, yrPlugin, gistPlugin, tweetPlugin, vinePlugin]
     };
 
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -57,6 +57,9 @@ weechat.factory('settings', ['$store', '$rootScope', function($store, $rootScope
 		for (var key in defaults) {
 			// null means the key isn't set
 			if ($store.get(key) === null) {
+				// Define property so it will get saved to store
+				defineProperty(key);
+				// Save to settings module AND to store
 				this[key] = defaults[key];
 			}
 		}

--- a/js/websockets.js
+++ b/js/websockets.js
@@ -110,7 +110,6 @@ function($rootScope, $q) {
             $rootScope.$emit('onMessage', message);
         }
 
-        $rootScope.$apply();
     };
 
     var connect = function(url,

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Glowing Bear",
   "description": "WeeChat Web frontend",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "manifest_version": 2,
   "icons": {
     "32": "assets/img/favicon.png",

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -25,5 +25,5 @@
       "desktop-notification":{}
   },
   "default_locale": "en",
-  "version": "0.4.4"
+  "version": "0.4.5"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glowing-bear",
   "private": true,
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "A web client for Weechat",
   "repository": "https://github.com/glowing-bear/glowing-bear",
   "license": "GPLv3",

--- a/test/unit/plugins.js
+++ b/test/unit/plugins.js
@@ -71,6 +71,16 @@ describe('filter', function() {
             plugins);
         }));
 
+        it('should recognize html5 videos', inject(function(plugins) {
+            expectTheseMessagesToContain([
+                'http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4',
+                'http://www.quirksmode.org/html5/videos/big_buck_bunny.webm',
+                'http://www.quirksmode.org/html5/videos/big_buck_bunny.ogv',
+            ],
+            'video',
+            plugins);
+        }));
+
         it('should recognize images', inject(function(plugins) {
             expectTheseMessagesToContain([
                 'http://i.imgur.com/BTNIDBR.gif',


### PR DESCRIPTION
I was recently travelling by train through an area with rather flaky mobile coverage, and it sucked to have to reconnect all the time, especially since GB throws you out of your current view and onto the landing page, so you can't even keep reading things that you already have offline. Instead, it would be nice to display a "reconnecting..." banner, and try to reconnect periodically, and allow the user to take up where they left off.

Ideas to take this even further:
- command queue while offline (send this to that buffer)

Things that need to be done before this can be merged:
- The UI is currently really bad. It covers actual text, and hasn't been tested on mobile
- A "reconnect now" link needs to be added (exponential backoff → timeouts can become quite large)
- Needs to be tested in a range of scenarios

You can try this out by manually closing the connection in WeeChat (/relay → D), or disturbing your internet connection in a way that doesn't run into a timeout (on a phone, that would be switching from mobile network to wifi or the other way around)


TODO:
* [x] reconnect now button
* [ ] make sure we get **all** new lines, which is not always the case (I suspect filtered lines)