### PR TITLE
Fix bufferlist spacing on mobile

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -557,6 +557,10 @@ li.buffer.indent.private a {
         min-height: 0%;
     }
 
+    .nav-pills > li > a {
+        padding: 10px 15px;
+    }
+
     #bufferlines {
         height: 100%;
         padding-bottom: 0;


### PR DESCRIPTION
The current version is much too tight to hit, and for some reason I only
fixed it in the cordova branch. This should go into master, though.
