### PR TITLE
Fix font size and timestamp positioning issues on mobile

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -593,12 +593,12 @@ li.buffer.indent.private a {
 
     #bufferlines td.time {
         padding-right: 3px;
-        font-size: 12px;
+        font-size: 0.8em;
     }
 
     #bufferlines td.time span.date {
         display: block;
-        margin-top: -2px;
+        margin-bottom: -1px;
     }
 
     #bufferlines td.prefix {
@@ -606,7 +606,7 @@ li.buffer.indent.private a {
         padding-right: 5px;
         border: 0;
         font-weight: bold;
-        font-size: 15px;
+        font-size: 1.06em;
     }
 
     #bufferlines td.message {


### PR DESCRIPTION
By using relative sizes, we automatically adjust to any change in the font size setting
Also, the timestamp shouldn't be lifted up, that looks weird. A `margin-bottom: -1px` does the CSS engine spell of confusion as well and doesn't mess up the layout.

Fixes #495 
