### PR TITLE
Introduce a new media query list for wide screens

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -534,6 +534,30 @@ img.emoji {
    vertical-align: -0.1em;
 }
 
+@media (min-width: 1400px) {
+    #sidebar[data-state=visible], #sidebar {
+        width: 200px;
+    }
+    .content[sidebar-state="visible"] #bufferlines {
+        margin-left: 205px;
+    }
+    #topbar .title {
+        left: 205px;
+    }
+    .content[sidebar-state=visible] .footer {
+        padding-left: 200px;
+    }
+    #nicklist {
+        width: 140px;
+    }
+    .withnicklist {
+      margin-right: 140px !important; /* nicklist */
+    }
+    .footer.withnicklist {
+        padding-right: 148px !important;
+    }
+}
+
 /* */
 /* Mobile layout */
 /* */


### PR DESCRIPTION
This change introduces a new media query that activates if the window is
wider than 1400px. It will then increase bufferlist width from 140px to
200px and nicklist from 100px to 140px.

If someone has better ideas than 1400px as a cutoff I am all ears to
that.

There might also be more changes we could do that further improves upon
this concept.