### PR TITLE
Fix bufferlist CSS transform for WebKit

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -573,15 +573,18 @@ img.emoji {
 
     #sidebar[data-state=visible] {
         transform: translate(0,0);
+        -webkit-transform: translate(0,0); /* Safari */
     }
 
     #sidebar[data-state=hidden] {
         transform: translate(-200px,0);
+        -webkit-transform: translate(-200px,0);
     }
 
     .content[sidebar-state=visible] #bufferlines, .content[sidebar-state=visible] .footer {
         margin-left: 0px;
         transform: translate(200px,0);
+        -webkit-transform: translate(200px,0);
     }
 
     #topbar .title {


### PR DESCRIPTION
iOS, Safari, and the stock Android browser (up to 4.4) seem to need this