### PR TITLE
[WIP] Fix commands for buffers whose fullname contain whitespace

### DIFF
--- a/js/connection.js
+++ b/js/connection.js
@@ -246,7 +246,7 @@ weechat.factory('connection',
      */
     var sendMessage = function(message) {
         ngWebsockets.send(weeChat.Protocol.formatInput({
-            buffer: models.getActiveBuffer().fullName,
+            buffer: models.getActiveBufferReference(),
             data: message
         }));
     };

--- a/js/models.js
+++ b/js/models.js
@@ -452,6 +452,22 @@ models.service('models', ['$rootScope', '$filter', function($rootScope, $filter)
     };
 
     /*
+     * Returns a reference to the currently active buffer that
+     * WeeChat understands without crashing, even if it's invalid
+     *
+     * @return active buffer pointer (WeeChat 1.0+) or fullname (older versions)
+     */
+    this.getActiveBufferReference = function() {
+        if (this.version !== null && parseInt(this.version.charAt(0)) >= 1) {
+            // pointers are being validated, they're more reliable than
+            // fullName (e.g. if fullName contains spaces)
+            return activeBuffer.id;
+        } else {
+            return activeBuffer.fullName;
+        }
+    };
+
+    /*
      * Returns the previous current active buffer
      *
      * @return previous buffer object

--- a/js/models.js
+++ b/js/models.js
@@ -461,7 +461,7 @@ models.service('models', ['$rootScope', '$filter', function($rootScope, $filter)
         if (this.version !== null && parseInt(this.version.charAt(0)) >= 1) {
             // pointers are being validated, they're more reliable than
             // fullName (e.g. if fullName contains spaces)
-            return activeBuffer.id;
+            return "0x"+activeBuffer.id;
         } else {
             return activeBuffer.fullName;
         }


### PR DESCRIPTION
Use pointers if Weechat version is recent enough (1.0+).
Otherwise, not marking stuff as read is probably the lesser evil than crashing weechat...

Untested!

- [ ] figure out a solution for older WeeChat versions