### PR TITLE
Add scrolling momentum to scrollable elements for mobile webkit

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -145,6 +145,7 @@ input[type=text], input[type=password], #sendMessage, .badge {
     height: 100%;
     overflow-y: auto;
     overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;
     padding-top: 35px; /* topbar */
     padding-bottom: 1px; /* need to force a padding here */
     font-size: smaller;
@@ -186,6 +187,7 @@ input[type=text], input[type=password], #sendMessage, .badge {
     height: 100%;
     overflow-y: auto;
     overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;
     right: 0;
     top: 0;
     padding-top: 39px;
@@ -240,6 +242,7 @@ input[type=text], input[type=password], #sendMessage, .badge {
     position: relative;
     height: 100%;
     overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
     width: auto;
     bottom: 35px;      /* input bar */
     padding-top: 42px; /* topbar */
@@ -379,6 +382,7 @@ table.notimestampseconds td.time span.seconds {
     z-index: 1000;
     height: 100%;
     overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
     position: absolute;
     top: 0;
     left: 0;

--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -382,7 +382,6 @@ table.notimestampseconds td.time span.seconds {
     z-index: 1000;
     height: 100%;
     overflow-y: scroll;
-    -webkit-overflow-scrolling: touch;
     position: absolute;
     top: 0;
     left: 0;


### PR DESCRIPTION
This is a tweak to PR #541(adds scrolling momentum to scrollable elements), as that PR seems to cause undesired scrolling issues (touches arbitrarily get absorbed; scrolling is sometimes impossible.)

I've tested this on two iOS devices running iOS 8.x and haven't encountered any scrolling issues.