### PR TITLE
Switch to buffer after issuing /query. Fixes #318

### DIFF
--- a/js/handlers.js
+++ b/js/handlers.js
@@ -107,10 +107,6 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
         var bufferMessage = message.objects[0].content[0];
         var buffer = new models.Buffer(bufferMessage);
         models.addBuffer(buffer);
-        /* Until we can decide if user asked for this buffer to be opened
-         * or not we will let user click opened buffers.
-        models.setActiveBuffer(buffer.id);
-        */
     };
 
     var handleBufferTitleChanged = function(message) {
@@ -138,6 +134,15 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
         // prefix + fullname, which would happen otherwise). Else, use null so that full_name is used
         old.trimmedName = obj.short_name.replace(/^[#&+]/, '') || (obj.short_name ? ' ' : null);
         old.prefix = ['#', '&', '+'].indexOf(obj.short_name.charAt(0)) >= 0 ? obj.short_name.charAt(0) : '';
+
+        // After a buffer openes we get the name change event from relay protocol
+        // Here we check our outgoing commands that openes a buffer and switch
+        // to it if we find the buffer name it the list
+        var position = models.outgoingQueries.indexOf(old.shortName);
+        if (position >= 0) {
+            models.outgoingQueries.splice(position, 1);
+            models.setActiveBuffer(old.id);
+        }
     };
 
     var handleBufferLocalvarChanged = function(message) {

--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -100,6 +100,19 @@ weechat.directive('inputBar', function() {
                         ab.clear();
                     }
 
+                    // Check against a list of commands that opens a new
+                    // buffer and save the name of the buffer so we can
+                    // also automatically switch to the new buffer in gb
+                    var opencommands = ['/query', '/join', '/j', '/q'];
+                    var spacepos = $scope.command.indexOf(' ');
+                    var firstword = $scope.command.substr(0, spacepos);
+                    var index = opencommands.indexOf(firstword);
+                    if (index >= 0) {
+                        var queryName = $scope.command.substring(spacepos + 1);
+                        // Cache our queries so when a buffer gets opened we can open in UI
+                        models.outgoingQueries.push(queryName);
+                    }
+
                     // Empty the input after it's sent
                     $scope.command = '';
                 }

--- a/js/models.js
+++ b/js/models.js
@@ -11,6 +11,9 @@ models.service('models', ['$rootScope', '$filter', function($rootScope, $filter)
     // WeeChat version
     this.version = null;
 
+    // Save outgoing queries
+    this.outgoingQueries = [];
+
     var parseRichText = function(text) {
         var textElements = weeChat.Protocol.rawText2Rich(text),
             typeToClassPrefixFg = {


### PR DESCRIPTION
Save outgoing /query nicks to a list and then check that list when we
get a buffer title rename and then switch to the buffer if the name
matches any nick in the outgoing list. Reason to use title event instead
of buffer opened event is that buffer open event doesn't contain the
short name. That would require parsing and guessing full names and in
general be more complicated (but maybe more correct)

This patch can be further improved in the future to check for existing
buffers and switch to them if they already exist.