### PR TITLE
Fix height of bufferlist items in narrow desktop view

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -226,6 +226,9 @@ input[type=text], input[type=password], #sendMessage {
     overflow: hidden;
 }
 
+.nav-pills li {
+    min-height: 20px;
+}
 .nav-pills li+li {
     margin-top: 0;
 }


### PR DESCRIPTION
That `overflow: hidden` really messes things up somehow