### PR TITLE
Fix 404 Error in OS X and Linux

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -3,10 +3,10 @@
   "description": "WeeChat Web frontend",
   "launch_path": "www.glowing-bear.org/index.html",
   "icons": {
-    "128": "/glowing-bear/assets/img/glowing_bear_128x128.png",
-    "60": "/glowing-bear/assets/img/glowing_bear_60x60.png",
-    "90": "/glowing-bear/assets/img/glowing_bear_90x90.png",
-    "32": "/glowing-bear/assets/img/favicon.png"
+    "128": "www.glowing-bear.org/assets/img/glowing_bear_128x128.png",
+    "60": "www.glowing-bear.org/assets/img/glowing_bear_60x60.png",
+    "90": "www.glowing-bear.org/assets/img/glowing_bear_90x90.png",
+    "32": "www.glowing-bear.org/assets/img/favicon.png"
   },
   "installs_allowed_from": [
     "*"

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -1,12 +1,12 @@
 {
   "name": "Glowing Bear",
   "description": "WeeChat Web frontend",
-  "launch_path": "www.glowing-bear.org/index.html",
+  "launch_path": "/index.html",
   "icons": {
-    "128": "www.glowing-bear.org/assets/img/glowing_bear_128x128.png",
-    "60": "www.glowing-bear.org/assets/img/glowing_bear_60x60.png",
-    "90": "www.glowing-bear.org/assets/img/glowing_bear_90x90.png",
-    "32": "www.glowing-bear.org/assets/img/favicon.png"
+    "128": "/assets/img/glowing_bear_128x128.png",
+    "60": "/assets/img/glowing_bear_60x60.png",
+    "90": "/assets/img/glowing_bear_90x90.png",
+    "32": "/assets/img/favicon.png"
   },
   "installs_allowed_from": [
     "*"

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Glowing Bear",
   "description": "WeeChat Web frontend",
-  "launch_path": "/glowing-bear/index.html",
+  "launch_path": "www.glowing-bear.org/index.html",
   "icons": {
     "128": "/glowing-bear/assets/img/glowing_bear_128x128.png",
     "60": "/glowing-bear/assets/img/glowing_bear_60x60.png",


### PR DESCRIPTION
In OS X and Linux when the app is launched, it 404s. Making the launch path the url of glowing-bear fixes this issue.