### PR TITLE
Re-implement click to join functionality.

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -24,7 +24,7 @@ weechat.filter('toArray', function () {
     };
 });
 
-weechat.filter('irclinky', ['$filter', function($filter) {
+weechat.filter('irclinky', function() {
     return function(text) {
         if (!text) {
             return text;
@@ -36,12 +36,12 @@ weechat.filter('irclinky', ['$filter', function($filter) {
         // "#1" is much more likely to be "number 1" than "IRC channel #1".
         // Thus, we only match channels beginning with a # and having at least one letter in them.
         var channelRegex = /(^|[\s,.:;?!"'()+@-\~%])(#+[^\x00\x07\r\n\s,:]*[a-z][^\x00\x07\r\n\s,:]*)/gmi;
-        // This is SUPER nasty, but ng-click does not work inside a filter, as the markup has to be $compiled first, which is not possible in filter afaik.
-        // Therefore, get the scope, fire the method, and $apply. Yuck. I sincerely hope someone finds a better way of doing this.
-        var substitute = '$1<a href="#" onclick="var $scope = angular.element(event.target).scope(); $scope.openBuffer(\'$2\'); $scope.$apply();">$2</a>';
+        // Call the method we bound to window.openBuffer when we instantiated
+        // the Weechat controller.
+        var substitute = '$1<a href="#" onclick="openBuffer(\'$2\');">$2</a>';
         return text.replace(channelRegex, substitute);
     };
-}]);
+});
 
 weechat.filter('inlinecolour', function() {
     return function(text) {

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -15,6 +15,11 @@ weechat.config(['$compileProvider', function ($compileProvider) {
 weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout', '$log', 'models', 'connection', 'notifications', 'utils', 'settings',
     function ($rootScope, $scope, $store, $timeout, $log, models, connection, notifications, utils, settings) {
 
+    window.openBuffer = function(channel) {
+        $scope.openBuffer(channel);
+        $scope.$apply();
+    };
+
     $scope.command = '';
     $scope.themes = ['dark', 'light'];
 

--- a/test/unit/filters.js
+++ b/test/unit/filters.js
@@ -16,11 +16,11 @@ describe('Filters', function() {
         }));
 
         it('should linkify IRC channels', inject(function(irclinkyFilter) {
-            expect(irclinkyFilter('#foo')).toEqual('<a href="#" onclick="var $scope = angular.element(event.target).scope(); $scope.openBuffer(\'#foo\'); $scope.$apply();">#foo</a>');
+            expect(irclinkyFilter('#foo')).toEqual('<a href="#" onclick="openBuffer(\'#foo\');">#foo</a>');
         }));
 
         it('should not mess up IRC channels surrounded by HTML entities', inject(function(irclinkyFilter) {
-            expect(irclinkyFilter('<"#foo">')).toEqual('<"<a href="#" onclick="var $scope = angular.element(event.target).scope(); $scope.openBuffer(\'#foo">\'); $scope.$apply();">#foo"></a>');
+            expect(irclinkyFilter('<"#foo">')).toEqual('<"<a href="#" onclick="openBuffer(\'#foo">\');">#foo"></a>');
         }));
     });
 


### PR DESCRIPTION
Clicking channel names to join broke because of angular [issue 9515](https://github.com/angular/angular.js/issues/9515). I reimplement the functionality by defining a custom directive which binds the scope to a DOM element and access it from an onclick handler.

It's still nasty.