### PR TITLE
Fixes problem with Firefox word / line breaking

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -34,13 +34,11 @@ td.message {
     padding: 1px 1px 1px 5px;
 
 -ms-word-break: break-all;
-    word-break: break-all;
 
     /* Non standard for webkit */
     word-break: break-word;
 
 -webkit-hyphens: auto;
-   -moz-hyphens: auto;
     -ms-hyphens: auto;
         hyphens: auto;
 


### PR DESCRIPTION
References #624.

Firefox would break long lines in the middle of words, disregarding hyphenation rules resulting in poor readability. This change fixes that behavior while still preventing very long unbreakable strings from showing a horizontal scrollbar.

Tested in Firefox 38.0.5 and Google Chrome 43.0.2357.124 (64-bit)
Note the difference between Firefox and Chrome: Firefox splits words with a hyphen to fit them on the line, Chrome moves the entire word to the next line.
I prefer Chrome's way and I wish Firefox would also just move the word to the next line, but I was unable to fix that. Any fix I tried to come up with resulted in Firefox bringing back the horizontal scrollbar for long strings such as urls.

Anyway, have a look at this fix and let me know if it breaks anything. Check my comment on the issue about the word-wrap approach. It breaks long urls.

Cheers!

Michael
