### PR TITLE
Handle hidden weechat buffers

### DIFF
--- a/js/connection.js
+++ b/js/connection.js
@@ -62,7 +62,7 @@ weechat.factory('connection',
                 return ngWebsockets.send(
                     weeChat.Protocol.formatHdata({
                         path: 'buffer:gui_buffers(*)',
-                        keys: ['local_variables,notify,number,full_name,short_name,title']
+                        keys: ['local_variables,notify,number,full_name,short_name,title,hidden']
                     })
                 );
             };

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -654,9 +654,9 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
             if (buffer.fullName === "core.weechat") {
                 return true;
             }
-            return buffer.unread > 0 || buffer.notification > 0;
+            return (buffer.unread > 0 || buffer.notification > 0) && !buffer.hidden;
         }
-        return true;
+        return !buffer.hidden;
     };
 
     // Watch model and update show setting when it changes

--- a/js/handlers.js
+++ b/js/handlers.js
@@ -81,6 +81,7 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
         buffer.trimmedName = buffer.shortName.replace(/^[#&+]/, '');
         buffer.title = message.title;
         buffer.number = message.number;
+        buffer.hidden = message.hidden;
 
         // reset these, hotlist info will arrive shortly
         buffer.notification = 0;
@@ -143,6 +144,20 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
             models.outgoingQueries.splice(position, 1);
             models.setActiveBuffer(old.id);
         }
+    };
+
+    var handleBufferHidden = function(message) {
+        var obj = message.objects[0].content[0];
+        var buffer = obj.pointers[0];
+        var old = models.getBuffer(buffer);
+        old.hidden = true;
+    };
+
+    var handleBufferUnhidden = function(message) {
+        var obj = message.objects[0].content[0];
+        var buffer = obj.pointers[0];
+        var old = models.getBuffer(buffer);
+        old.hidden = false;
     };
 
     var handleBufferLocalvarChanged = function(message) {
@@ -253,6 +268,8 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
         _buffer_opened: handleBufferOpened,
         _buffer_title_changed: handleBufferTitleChanged,
         _buffer_renamed: handleBufferRenamed,
+        _buffer_hidden: handleBufferHidden,
+        _buffer_unhidden: handleBufferUnhidden,
         _nicklist: handleNicklist,
         _nicklist_diff: handleNicklistDiff
     };

--- a/js/models.js
+++ b/js/models.js
@@ -63,6 +63,7 @@ models.service('models', ['$rootScope', '$filter', function($rootScope, $filter)
         // weechat properties
         var fullName = message.full_name;
         var shortName = message.short_name;
+        var hidden = message.hidden;
         // If it's a channel, trim away the prefix (#, &, or +). If that is empty and the buffer
         // has a short name, use a space (because the prefix will be displayed separately, and we don't want
         // prefix + fullname, which would happen otherwise). Else, use null so that full_name is used
@@ -289,6 +290,7 @@ models.service('models', ['$rootScope', '$filter', function($rootScope, $filter)
             id: pointer,
             fullName: fullName,
             shortName: shortName,
+            hidden: hidden,
             trimmedName: trimmedName,
             prefix: prefix,
             number: number,


### PR DESCRIPTION
This adds a new 'hidden' field to the Buffer model, which stays in sync with weechat's notion of hidden buffers.