### PR TITLE
Always show server buffers in hierarchical view

### DIFF
--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -651,7 +651,8 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
                 return true;
             }
             // Always show core buffer in the list (issue #438)
-            if (buffer.fullName === "core.weechat") {
+            // Also show server buffers in hierarchical view
+            if (buffer.fullName === "core.weechat" || (settings.orderbyserver && buffer.type === 'server')) {
                 return true;
             }
             return buffer.unread > 0 || buffer.notification > 0;


### PR DESCRIPTION
Show them even if 'Only show buffers with unread messages' is set

suggested by `afics` on IRC