### PR TITLE
simplify giphy regex matching and use original url for image link

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -363,8 +363,6 @@ plugins.factory('userPlugins', function() {
         var id = url.match(regex);
         if (id) {
             var src = "https://media.giphy.com/media/" + id[1] + "/giphy.gif";
-            /* upgrade any http url to tls, yeah crypto */
-            if (url.match(/^http:/i)) { url.replace(/^http:/, "https:"); }
             return '<a target="_blank" href="'+url+'"><img class="embed" src="' + src + '"></a>';
         }
     });

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -358,17 +358,14 @@ plugins.factory('userPlugins', function() {
   * sample output: https://media.giphy.com/media/feqkVgjJpYtjy/giphy.gif
   */
     var giphyPlugin = new UrlPlugin('Giphy', function(url) {
-        var regex = /^https?:\/\/giphy.com\/gifs\/.*-.*\/?/i;
-        if (url.match(regex)) {
-            /* if the url does not contain a trailing slash, add it */
-            if (! url.match(/\/$/i)) { url = url + "/"; }
-            /* upgrade any http links to tls, yeah crypto */
-            if (url.match(/^http:/i)) { url.replace(/http:/, "https:"); }
-            /* change the url to refrence the giphy cdn url, not the userfacing webserver */
-            url = url.replace(/\/giphy.com\//i,"/media.giphy.com/");
-            url = url.replace(/\/gifs\/.*-/i,"/media/");
-            url = url + "giphy.gif";
-            return '<a target="_blank" href="'+url+'"><img class="embed" src="' + url + '"></a>';
+        var regex = /^https?:\/\/giphy.com\/gifs\/.*-(.*)\/?/i;
+        // on match, id will contain the entire url in [0] and the giphy id in [1]
+        var id = url.match(regex);
+        if (id) {
+            var src = "https://media.giphy.com/media/" + id[1] + "/giphy.gif";
+            /* upgrade any http url to tls, yeah crypto */
+            if (url.match(/^http:/i)) { url.replace(/^http:/, "https:"); }
+            return '<a target="_blank" href="'+url+'"><img class="embed" src="' + src + '"></a>';
         }
     });
 


### PR DESCRIPTION
I realized that my code was a tad confusing, so I cleaned it up, removed all but two str.match() calls, and have the image link to the user-facing url, now https if not sent that way, not the cdn gif image as before.

The old testcases should still pass for the new code, so they remain unchanged.