### PR TITLE
IPv6 address literals won't be surrounded by [ ... ] if it's already there

### DIFF
--- a/js/connection.js
+++ b/js/connection.js
@@ -20,7 +20,7 @@ weechat.factory('connection',
         connectionData = [host, port, passwd, ssl, noCompression];
         var proto = ssl ? 'wss' : 'ws';
         // If host is an IPv6 literal wrap it in brackets
-        if (host.indexOf(":") !== -1) {
+        if (host.indexOf(":") !== -1 && host[0] !== "[" && host[host.length-1] !== "]") {
             host = "[" + host + "]";
         }
         var url = proto + "://" + host + ":" + port + "/weechat";


### PR DESCRIPTION
simple fix. Tested it on my ipv6 server, was able to connect. Tried "[address]", "address", and "[[address]]". Only the last failed.

Do you want me to add a test case for this somehow? I assume it would be one of these protractor end-to-end tests referenced in the readme, but I think that for a tester to run the test successfully, they would have to have a machine capable of supporting ipv6 which my machine doesn't so it doesn't sound like they're super widespread yet.

-pj2melan