### PR TITLE
adding imgur gifv support to the videoPlugin

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -302,10 +302,14 @@ plugins.factory('userPlugins', function() {
      * mp4 video Preview
      */
     var videoPlugin = new UrlPlugin('video', function(url) {
-        if (url.match(/\.(mp4|webm|ogv)\b/i)) {
+        if (url.match(/\.(mp4|webm|ogv|gifv)\b/i)) {
+            if (url.match(/^http:\/\/(i\.)?imgur\.com\//i)) {
+                // remove protocol specification to load over https if used by g-b
+                url = url.replace(/\.(gifv)\b/i, ".webm");
+            }
             return function() {
                 var element = this.getElement();
-                var velement = angular.element('<video></video>')
+                var velement = angular.element('<video autoplay loop muted></video>')
                                      .addClass('embed')
                                      .attr('width', '560')
                                      .append(angular.element('<source></source>')
@@ -314,6 +318,7 @@ plugins.factory('userPlugins', function() {
             };
         }
     });
+    
 
     /*
      * Cloud Music Embedded Players


### PR DESCRIPTION
This just required a slight hack, because all of the gifv files are webm files (if you change the end of the filename to webm it'll go to the video still). Playback didn't work by just assuming we could play gifv, but changing the file extension to .webm did the trick.