### PR TITLE
date change messages are chat_day_change color, multiple messages gerated for diff of 1-5 days

### DIFF
--- a/js/handlers.js
+++ b/js/handlers.js
@@ -21,11 +21,11 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
 
     // inject a fake buffer line for date change
     var injectDateChangeMessage = function(message, buffer, date) {
-        var content = "Date changed to " + date.toDateString();
+        var content = "\u001943Date changed to " + date.toDateString();
         var line = {
             buffer: buffer,
             date: date,
-            prefix: '—',
+            prefix: '\u001943\u2500\u2500',
             tags_array: [],
             displayed: true,
             highlight: 0,
@@ -47,8 +47,24 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
                     current_date = new Date(message.date);
                 previous_date.setHours(0, 0, 0, 0);
                 current_date.setHours(0, 0, 0, 0);
-                if (previous_date.valueOf() !== current_date.valueOf()) {
-                     injectDateChangeMessage(message, buffer, current_date);
+                var dateDifference =
+                    Math.round((current_date - previous_date)/(24*60*60*1000));
+                if (dateDifference !== 0) {
+                    console.log(dateDifference);
+                    // if it's a small, positive number display a message
+                    // for each one. Otherwise, just display one big
+                    // date change message
+                    // The range [1,5] was chosen arbitrarily
+                    if (dateDifference >= 1 && dateDifference <= 5) {
+                        var prev_date_clone = previous_date;
+                        for (var i = 1; i <= dateDifference; ++i) {
+                            prev_date_clone.setDate(prev_date_clone.getDate()+1);
+                            injectDateChangeMessage(message, buffer,
+                                                    prev_date_clone);
+                        }
+                    } else {
+                        injectDateChangeMessage(message, buffer, current_date);
+                    }
                 }
             }
 

--- a/js/weechat.js
+++ b/js/weechat.js
@@ -290,7 +290,7 @@
                     var ret = {};
                     var optionCode = parseInt(m[1]);
 
-                    if (optionCode > 43) {
+                    if (optionCode >= WeeChatProtocol._colorsOptionsNames.length) {
                         // should never happen
                         return {
                             fgColor: null,


### PR DESCRIPTION
PR for discussion.

Two changes here,

1. the date change message is now a pretty color (specifically, chat_day_change). To do this, I had to change this one line in `js/weechat.js`. I'll point that out in a line comment.

2. If the difference between the current date and the previous message's date is 1-5 dates, inclusive, then it will generate that many date change messages. If it's outside of that range (for example, negative date ranges) only one date change message is generated. I've attached some screenshots of this behaviour.

http://i.imgur.com/7OGs1jF.png (sorry for imgur, git wasn't uploading it properly. I'm on greyhound bus wifi atm.)