### PR TITLE
disallow nested links in DOMfilter (fixes #680)

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -61,10 +61,15 @@ weechat.filter('inlinecolour', function() {
 
 // apply a filter to an HTML string's text nodes, and do so with not exceedingly terrible performance
 weechat.filter('DOMfilter', ['$filter', '$sce', function($filter, $sce) {
+    // To prevent nested anchors, we need to know if a filter is going to create them.
+    // Here's a list of names. See #681 for more information.
+    var filtersThatCreateAnchors = ['irclinky'];
+
     return function(text, filter) {
         if (!text || !filter) {
             return text;
         }
+        var createsAnchor = filtersThatCreateAnchors.indexOf(filter) > -1;
 
         var escape_html = function(text) {
             // First, escape entities to prevent escaping issues because it's a bad idea
@@ -92,6 +97,7 @@ weechat.filter('DOMfilter', ['$filter', '$sce', function($filter, $sce) {
                 // as innerHTML causes it to be unescaped.
                 var input = escape_html(node.nodeValue);
                 var value = filterFunction(input, extraArgument, thirdArgument);
+
                 if (value !== input) {
                     // we changed something. create a new node to replace the current one
                     // we could also only add its children but that would probably incur
@@ -114,7 +120,11 @@ weechat.filter('DOMfilter', ['$filter', '$sce', function($filter, $sce) {
             if (node === undefined || node === null) return;
             node = node.firstChild;
             while (node) {
-                var nextNode = process(node);
+                var nextNode;
+                // do not recurse inside links if the filter would create a nested link
+                if (!(createsAnchor && node.tagName === 'A')) {
+                    nextNode = process(node);
+                }
                 node = (nextNode ? nextNode : node).nextSibling;
             }
         };

--- a/test/unit/filters.js
+++ b/test/unit/filters.js
@@ -22,6 +22,13 @@ describe('Filters', function() {
         it('should not mess up IRC channels surrounded by HTML entities', inject(function(irclinkyFilter) {
             expect(irclinkyFilter('<"#foo">')).toEqual('<"<a href="#" onclick="openBuffer(\'#foo">\');">#foo"></a>');
         }));
+
+        it('should not touch links created by `linky`', inject(function(linkyFilter, DOMfilterFilter) {
+            var url = 'http://foo.bar/#baz',
+                link = linkyFilter(url, '_blank'),
+                result = DOMfilterFilter(link, 'irclinky').$$unwrapTrustedValue();
+            expect(result).toEqual(link);
+        }));
     });
 
     describe('inlinecolour', function() {
@@ -62,4 +69,19 @@ describe('Filters', function() {
         }));
     });
 
+    describe('DOMfilter', function() {
+        it('should run a filter on all text nodes', inject(function(DOMfilterFilter) {
+            var dom = 'a<p>b<i>c<b>d</b>e<b>f</b>g</i>h</p>i',
+                expected = '<span>A</span><p><span>B</span><i><span>C</span><b><span>D</span></b><span>E</span><b><span>F</span></b><span>G</span></i><span>H</span></p><span>I</span>',
+                result = DOMfilterFilter(dom, 'uppercase').$$unwrapTrustedValue();
+            expect(result).toEqual(expected);
+        }));
+
+        it('should pass additional arguments to the filter', inject(function(DOMfilterFilter) {
+            var dom = '1<p>2</p>3.14159265',
+                expected = '<span>1.00</span><p><span>2.00</span></p><span>3.14</span>',
+                result = DOMfilterFilter(dom, 'number', 2).$$unwrapTrustedValue();
+            expect(result).toEqual(expected);
+        }));
+    });
 });


### PR DESCRIPTION
Here's an idea. Nested `<a>` tags are disallowed per the HTML spec, and skipping filters that would create them would fix #680. This should not cause a notable performance hit, especially considering there should not be much content inside link tags anyway.