### PR TITLE
Date change at the end of the buffer when changing buffers, more HR dates

### DIFF
--- a/js/handlers.js
+++ b/js/handlers.js
@@ -30,23 +30,49 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
         // plus one day will be time 00:00:00
         old_date_plus_one.setHours(0, 0, 0, 0);
 
-        var content = "\u001943" + // styling
-            "Date changed to " + new_date.toDateString();
+        var content = "\u001943"; // this colour corresponds to chat_day_change
+        content += new_date.toLocaleDateString(window.navigator.language,
+                                               {weekday: "long"});
+        // if you're testing different date formats,
+        // make sure to test different locales such as "en-US",
+        // "en-US-u-ca-persian" (which has different weekdays, year 0, and an ERA)
+        // "ja-JP-u-ca-persian-n-thai" (above, diff numbering, diff text)
+        var extra_date_format = {
+            day: "numeric",
+            month: "long"
+        };
+        if (new_date.getYear() !== old_date.getYear()) {
+            extra_date_format.year = "numeric";
+        }
+        content += " (";
+        content += new_date.toLocaleDateString(window.navigator.language,
+                                               extra_date_format);
+        // Result should be something like
+        // Friday (November 27)
+        // or if the year is different,
+        // Friday (November 27, 2015)
+
         // Comparing dates in javascript is beyond tedious
         if (old_date_plus_one.valueOf() !== new_date.valueOf()) {
-            var date_diff = Math.round((new_date - old_date)/(24*60*60*1000));
+            var date_diff = Math.round((new_date - old_date)/(24*60*60*1000)) + 1;
             if (date_diff < 0) {
-                date_diff = -1*(date_diff + 1);
-                content += " (" + date_diff + " days before " + old_date.toDateString() + ")";
+                date_diff = -1*(date_diff);
+                if (date_diff === 1) {
+                    content += ", 1 day before";
+                } else {
+                    content += ", " + date_diff + " days before";
+                }
             } else {
-                content += " (" + date_diff + " days have passed since  " + old_date.toDateString() + ")";
+                content += ", " + date_diff + " days later";
             }
+            // Result: Friday (November 27, 5 days later)
         }
+        content += ")";
 
         var line = {
             buffer: buffer,
             date: new_date,
-            prefix: '\u001943\u2500\u2500',
+            prefix: '\u001943\u2500',
             tags_array: [],
             displayed: true,
             highlight: 0,


### PR DESCRIPTION
Two changes here.

First, if you change buffer into a buffer where the last message wasn't the current day, injects a date change message.

Second, changed the format of the names. The new behaviour is contained in the commit message of 9334f44

Thoughts?

I've been messing around with setting a different timezone on my weechat relay, just to make sure the whole timezone thing works. As such, I'm going to make this PR, then maybe stay up until midnight local time and see if it generates a date change message.

Dates are fun.