### PR TITLE
Date change fixes

### DIFF
--- a/js/connection.js
+++ b/js/connection.js
@@ -62,7 +62,7 @@ weechat.factory('connection',
                 return ngWebsockets.send(
                     weeChat.Protocol.formatHdata({
                         path: 'buffer:gui_buffers(*)',
-                        keys: ['local_variables,notify,number,full_name,short_name,title,hidden']
+                        keys: ['local_variables,notify,number,full_name,short_name,title,hidden,type']
                     })
                 );
             };

--- a/js/handlers.js
+++ b/js/handlers.js
@@ -21,6 +21,10 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
 
     // inject a fake buffer line for date change if needed
     var injectDateChangeMessageIfNeeded = function(buffer, old_date, new_date) {
+        if (buffer.bufferType === 1) {
+            // Don't add date change messages to free buffers
+            return;
+        }
         old_date.setHours(0, 0, 0, 0);
         new_date.setHours(0, 0, 0, 0);
         // Check if the date changed
@@ -247,6 +251,14 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
         }
     };
 
+    var handleBufferTypeChanged = function(message) {
+        var obj = message.objects[0].content[0];
+        var buffer = obj.pointers[0];
+        var old = models.getBuffer(buffer);
+        // 0 = formatted (normal); 1 = free
+        buffer.bufferType = obj.type;
+    };
+
     /*
      * Handle answers to (lineinfo) messages
      *
@@ -262,9 +274,9 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
         });
         if (message.objects[0].content.length > 0) {
             // fiddle out the buffer ID and take the last line's date
-            var last_object =
+            var last_line =
                 message.objects[0].content[message.objects[0].content.length-1];
-            var buffer = models.getBuffer(last_object.buffer);
+            var buffer = models.getBuffer(last_line.buffer);
             if (buffer.lines.length > 0) {
                 var last_date = new Date(buffer.lines[buffer.lines.length - 1].date);
                 injectDateChangeMessageIfNeeded(buffer, last_date, new Date());
@@ -351,6 +363,7 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
         _buffer_localvar_changed: handleBufferLocalvarChanged,
         _buffer_opened: handleBufferOpened,
         _buffer_title_changed: handleBufferTitleChanged,
+        _buffer_type_changed: handleBufferTypeChanged,
         _buffer_renamed: handleBufferRenamed,
         _buffer_hidden: handleBufferHidden,
         _buffer_unhidden: handleBufferUnhidden,

--- a/js/handlers.js
+++ b/js/handlers.js
@@ -261,11 +261,14 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
             handleLine(l, manually);
         });
         if (message.objects[0].content.length > 0) {
-            var last_line =
+            // fiddle out the buffer ID and take the last line's date
+            var last_object =
                 message.objects[0].content[message.objects[0].content.length-1];
-            var last_message = new models.BufferLine(last_line);
-            var buffer = models.getBuffer(last_message.buffer);
-            injectDateChangeMessageIfNeeded(buffer, last_message.date, new Date());
+            var buffer = models.getBuffer(last_object.buffer);
+            if (buffer.lines.length > 0) {
+                var last_date = new Date(buffer.lines[buffer.lines.length - 1].date);
+                injectDateChangeMessageIfNeeded(buffer, last_date, new Date());
+            }
         }
     };
 

--- a/js/models.js
+++ b/js/models.js
@@ -85,6 +85,9 @@ models.service('models', ['$rootScope', '$filter', function($rootScope, $filter)
         var unread = 0;
         var lastSeen = -1;
         var serverSortKey = fullName.replace(/^irc\.server\.(\w+)/, "irc.$1");
+        // There are two kinds of types: bufferType (free vs formatted) and
+        // the kind of type that distinguishes queries from channels etc
+        var bufferType = message.type;
         var type = message.local_variables.type;
         var indent = (['channel', 'private'].indexOf(type) >= 0);
 
@@ -311,6 +314,7 @@ models.service('models', ['$rootScope', '$filter', function($rootScope, $filter)
             getNicklistByTime: getNicklistByTime,
             serverSortKey: serverSortKey,
             indent: indent,
+            bufferType: bufferType,
             type: type,
             history: history,
             addToHistory: addToHistory,


### PR DESCRIPTION
- Don't show the date change markers for free buffers (as opposed to regular formatted buffers)
- Don't mess up the last messages date. Javascript likes to pass things by reference