### PR TITLE
fix #688 and provide a unit test

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -120,7 +120,7 @@ weechat.filter('DOMfilter', ['$filter', '$sce', function($filter, $sce) {
             if (node === undefined || node === null) return;
             node = node.firstChild;
             while (node) {
-                var nextNode;
+                var nextNode = null;
                 // do not recurse inside links if the filter would create a nested link
                 if (!(createsAnchor && node.tagName === 'A')) {
                     nextNode = process(node);

--- a/test/unit/filters.js
+++ b/test/unit/filters.js
@@ -83,5 +83,13 @@ describe('Filters', function() {
                 result = DOMfilterFilter(dom, 'number', 2).$$unwrapTrustedValue();
             expect(result).toEqual(expected);
         }));
+
+        it('should never lock up like in bug #688', inject(function(linkyFilter, DOMfilterFilter) {
+            var msg = '#crash http://google.com',
+                linked = linkyFilter(msg),
+                irclinked = DOMfilterFilter(linked, 'irclinky');
+            // With the bug, the DOMfilterFilter call ends up in an infinite loop.
+            // I.e. if we ever got this far, the bug is fixed.
+        }));
     });
 });


### PR DESCRIPTION
Sorry about this. I kind of thought that the original code had a block-local variable, ES6 `let` style. But obviously `nextNode` is hoisted and retains its value, causing infinite loops with the new logic.

Last time I was lucky enough to think of a unit test that doesn't hit this bug, too... The new test doesn't test anything useful but does hang in an infinite loop if the issue exists.