### PR TITLE
prevent "zalgo text" from exiting the message/bufferline

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -29,6 +29,7 @@ td.prefix {
     border-right: 1px solid #444;
 }
 td.message {
+    overflow: hidden;
     vertical-align: top;
     width: 100%;
     padding: 1px 1px 1px 5px;
@@ -772,7 +773,13 @@ img.emojione {
         padding-bottom: 0;
     }
 
+    #bufferlines tr.bufferline {
+        display: block;
+        overflow: hidden;
+    }
+
     #bufferlines td.time {
+        display: inline-block;
         padding-right: 3px;
         font-size: 0.8em;
     }


### PR DESCRIPTION
For a review of what zalgo text is and how it works, see
http://stackoverflow.com/q/6579844/659526 . Suffice to say it abuses
unicode to create a vertical mess that goes over other lines of text.

This here patch adds `overflow: hidden` to two different places (for mobile/desktop). I briefly tested this and nothing seems to break, but given my track record I suggest reviewing before merging. :)

![Example of zalgo text](http://i.imgur.com/VtEY6OU.png)