### PR TITLE
#700 added fallback mode for unsupported .toLocaleDateString()

### DIFF
--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -761,6 +761,23 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         }
     };
 
+    $rootScope.supports_formatting_date = (function() {
+        // function toLocaleDateStringSupportsLocales taken from MDN:
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString#Checking_for_support_for_locales_and_options_arguments
+        try {
+            new Date().toLocaleDateString('i');
+        } catch (e) {
+            if (e.name !== 'RangeError') {
+                $log.info("Browser does not support toLocaleDateString()," +
+                          " falling back to en-US");
+            }
+            return e.name === 'RangeError';
+        }
+        $log.info("Browser does not support toLocaleDateString()," +
+                  " falling back to en-US");
+        return false;
+    })();
+
     // Prevent user from accidentally leaving the page
     window.onbeforeunload = function(event) {
 

--- a/js/handlers.js
+++ b/js/handlers.js
@@ -59,8 +59,16 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
 
             var content = "\u001943"; // this colour corresponds to chat_day_change
             // Add day of the week
-            content += new_date.toLocaleDateString(window.navigator.language,
-                                                   {weekday: "long"});
+            if ($rootScope.supports_formatting_date) {
+                content += new_date.toLocaleDateString(window.navigator.language,
+                                                       {weekday: "long"});
+            } else {
+                // Gross code that only does English dates ew gross
+                var dow_to_word = [
+                    "Sunday", "Monday", "Tuesday",
+                    "Wednesday", "Thursday", "Friday", "Saturday"];
+                content += dow_to_word[new_date.getDay()];
+            }
             // if you're testing different date formats,
             // make sure to test different locales such as "en-US",
             // "en-US-u-ca-persian" (which has different weekdays, year 0, and an ERA)
@@ -73,8 +81,20 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
                 extra_date_format.year = "numeric";
             }
             content += " (";
-            content += new_date.toLocaleDateString(window.navigator.language,
-                                                   extra_date_format);
+            if ($rootScope.supports_formatting_date) {
+                content += new_date.toLocaleDateString(window.navigator.language,
+                                                       extra_date_format);
+            } else {
+                // ew ew not more gross code
+                var month_to_word = [
+                    "January", "February", "March", "April",
+                    "May", "June", "July", "August",
+                    "September", "October", "November", "December"];
+                content += month_to_word[new_date.getMonth()] + " " + new_date.getDate().toString();
+                if (extra_date_format.year === "numeric") {
+                    content += ", " + new_date.getFullYear().toString();
+                }
+            }
             // Result should be something like
             // Friday (November 27)
             // or if the year is different,


### PR DESCRIPTION
Fixes #700 for iOS and any other browsers that don't properly support this one method taking arguments.

Fix is: detect if `Date.toLocaleDateString()` supports taking in a locale argument and a format options argument, and if the date formats properly then do the same thing we've been doing. Otherwise, keep track that it's not supported properly.
If it's not supported, fall back to a manual implementation of `en-US`. Yeah. With like lookups in arrays and stuff. It's not ideal, it's not internationalized, and I don't like it. Another solution is include a 3rd party JS libs but that's a lot so I left it as is.

I tried to keep performance impact when toLocaleDateString *is* supported to a minimum.

Want me to add a unit test or something? I tested this code by setting `supports_formatting_date = false` before it goes through the rest of the date change function, and it successfully output the right dates.

Thoughts?