### PR TITLE
#705 increment buffer.lastSeen on date change message

### DIFF
--- a/js/handlers.js
+++ b/js/handlers.js
@@ -29,6 +29,7 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
         new_date.setHours(0, 0, 0, 0);
         // Check if the date changed
         if (old_date.valueOf() !== new_date.valueOf()) {
+            ++buffer.lastSeen
             var old_date_plus_one = old_date;
             old_date_plus_one.setDate(old_date.getDate() + 1);
             // it's not always true that a date with time 00:00:00


### PR DESCRIPTION
This seems to fix #705 for me. To test, I clicked on an offending buffer in the bufferlist. There was one date change message, and the read marker was one line too high. I made the change, clicked on the buffer in the hotlist again, and the read marker was now set correctly.