### PR TITLE
use service workers for notifications

### DIFF
--- a/serviceworker.js
+++ b/serviceworker.js
@@ -1,0 +1,22 @@
+// File needs to be stored in the root of the app.
+
+this.addEventListener('install', function(event) {
+    event.waitUntil(
+        caches.open('v1').then(function(cache) {
+            return cache.addAll([
+                'assets/img/glowing_bear_128x128.png',
+            ]);
+        })
+    );
+});
+
+this.addEventListener('push', function(event) {
+    // TODO, support GCM here
+    var title = 'Push message';
+    event.waitUntil(
+        self.registration.showNotification(title, {
+          body: 'The Message',
+          icon: 'assets/img/favicon.png',
+          tag: 'my-tag'
+        }));
+});


### PR DESCRIPTION
If Service Workers are available use them to display notifications
instead of the old way of creating notifications directly.

This has the side effect that it works nicely on chrome on android which
the old method does not.

This also paves the way to set up GCM for push notification in the
future which can give us push notifications without having the app running.

This patch can be improved in the future to get existing notifications
and change the message instead of just adding more and more
notifications.

See: ServiceWorkerRegistration.getNotifications() and
ServiceWorkerRegistration.update() from
https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration