### PR TITLE
optimize what gets passed to emojione.unicodeToImage

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -161,7 +161,14 @@ weechat.filter('getBufferQuickKeys', function () {
 weechat.filter('emojify', function() {
     return function(text, enable_JS_Emoji) {
         if (enable_JS_Emoji === true && window.emojione !== undefined) {
-            return emojione.unicodeToImage(text);
+            // Emoji live in the D800-DFFF surrogate plane; only bother passing
+            // this range to CPU-expensive unicodeToImage();
+            var emojiRegex = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g;
+            if (emojiRegex.test(text)) {
+                return emojione.unicodeToImage(text);
+            } else {
+                return(text);
+            }
         } else {
             return(text);
         }


### PR DESCRIPTION
With "non-native Emoji support" enabled, *filters.js* is passing every chunk of text in a buffer to *emojione.unicodeToImage()*. This function is rather CPU expensive.

I profiled switching to the same buffer (that had a half-dozen emoji) multiple times in Google Chrome 47 on my Intel Core i7-4770. GB spent an average of **43.7ms** in *filters.js:161* (*weechat.filter(emojify)*). I added a RegExp.test to check if the chunk includes anything from the Unicode plane that emoji live in. A retest brought the average down to **2.8ms**. Testing on a buffer with no emoji at all didn't even make a blip on the profiler.