### PR TITLE
Fixed a circular ref in date change messages

### DIFF
--- a/js/handlers.js
+++ b/js/handlers.js
@@ -98,7 +98,7 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
             content += ")";
 
             var line = {
-                buffer: buffer,
+                buffer: buffer.id,
                 date: new_date,
                 prefix: '\u001943\u2500',
                 tags_array: [],


### PR DESCRIPTION
Before, `line.buffer` was the actual buffer object, which contains the injected date change message itself. Made this just a buffer id, which should be the same as other normal messages.

Not sure if this is exactly how we want it, but in my testing `line.buffer` of an injected date change message and `line.buffer` of a real message are both the same (eg `12b27c0`).

This is probably a good thing to fix. Let me know if you have thoughts.