### PR TITLE
#705 bugfix datechange injected under read marker

### DIFF
--- a/js/handlers.js
+++ b/js/handlers.js
@@ -41,7 +41,7 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
     };
 
     // inject a fake buffer line for date change if needed
-    var injectDateChangeMessageIfNeeded = function(buffer, old_date, new_date) {
+    var injectDateChangeMessageIfNeeded = function(buffer, manually, old_date, new_date) {
         if (buffer.bufferType === 1) {
             // Don't add date change messages to free buffers
             return;
@@ -50,9 +50,10 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
         new_date.setHours(0, 0, 0, 0);
         // Check if the date changed
         if (old_date.valueOf() !== new_date.valueOf()) {
-            if (buffer.lastSeen + 1 < buffer.lines.length) {
-                // if the date change should be injected below the read marker,
-                // adjust the read marker up to make sure it stays under the read marker
+            if (manually) {
+                // if the message that caused this date change to be sent
+                // would increment buffer.lastSeen, we should increment as
+                // well.
                 ++buffer.lastSeen;
             }
             var old_date_plus_one = old_date;
@@ -145,7 +146,7 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
             if (buffer.lines.length > 0) {
                 var old_date = new Date(buffer.lines[buffer.lines.length - 1].date),
                     new_date = new Date(message.date);
-                injectDateChangeMessageIfNeeded(buffer, old_date, new_date);
+                injectDateChangeMessageIfNeeded(buffer, manually, old_date, new_date);
             }
 
             message = plugins.PluginManager.contentForMessage(message);
@@ -330,7 +331,7 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
             var buffer = models.getBuffer(last_line.buffer);
             if (buffer.lines.length > 0) {
                 var last_date = new Date(buffer.lines[buffer.lines.length - 1].date);
-                injectDateChangeMessageIfNeeded(buffer, last_date, new Date());
+                injectDateChangeMessageIfNeeded(buffer, true, last_date, new Date());
             }
         }
     };

--- a/js/handlers.js
+++ b/js/handlers.js
@@ -50,7 +50,11 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
         new_date.setHours(0, 0, 0, 0);
         // Check if the date changed
         if (old_date.valueOf() !== new_date.valueOf()) {
-            ++buffer.lastSeen;
+            if (buffer.lastSeen + 1 < buffer.lines.length) {
+                // if the date change should be injected below the read marker,
+                // adjust the read marker up to make sure it stays under the read marker
+                ++buffer.lastSeen;
+            }
             var old_date_plus_one = old_date;
             old_date_plus_one.setDate(old_date.getDate() + 1);
             // it's not always true that a date with time 00:00:00


### PR DESCRIPTION
after #708 was merged, if a date change message is
injected underneath the read marker the read
marker would be one line too low. Now, the read
marker will adjust properly when a date change
message is injected above and below the read
marker.

thanks lorenzhs for spotting that. Does this fix the behavior? I've tested it myself, and it seems to have fixed the problem.

Behavior when:
1. print "old date" to buffer
2. navigate away
3. print "new date" with a different date to the buffer
4. navigate back and take screenshot (see before and after)
![before](https://cloud.githubusercontent.com/assets/1498589/12185795/59c85de6-b56b-11e5-900c-8ce6e6281345.png)
[before]

![after](https://cloud.githubusercontent.com/assets/1498589/12185754/07265e9e-b56b-11e5-9272-606fb137252c.png)
[after]
 
Yeah, thoughts?
