### PR TITLE
Changed word-break property for td.message to normal.

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -38,18 +38,16 @@ td.message {
     width: 100%;
     padding: 1px 1px 1px 5px;
 
--ms-word-break: break-all;
-    word-break: break-all;
+    -ms-word-break: normal;
+    word-break: normal;
 
-    /* Non standard for webkit */
-    word-break: break-word;
-
--webkit-hyphens: auto;
-   -moz-hyphens: auto;
+    -webkit-hyphens: auto;
+    -moz-hyphens: auto;
     -ms-hyphens: auto;
         hyphens: auto;
 
 }
+
 
 #readmarker {
     margin-top: 5px;


### PR DESCRIPTION
The messages break-between-any-letter styling was bugging me, as it made some messages very difficult to read, so I created a stylish script with these rules. It seems to be working properly with that, and isn't interfering with links, so I added it directly to the stylesheet here.