### PR TITLE
WebApp not working: Need to remove /glowing-bear prefix from urls.

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -1,12 +1,12 @@
 {
   "name": "Glowing Bear",
   "description": "WeeChat Web frontend",
-  "launch_path": "/glowing-bear/index.html",
+  "launch_path": "/index.html",
   "icons": {
-    "128": "/glowing-bear/assets/img/glowing_bear_128x128.png",
-    "60": "/glowing-bear/assets/img/glowing_bear_60x60.png",
-    "90": "/glowing-bear/assets/img/glowing_bear_90x90.png",
-    "32": "/glowing-bear/assets/img/favicon.png"
+    "128": "/assets/img/glowing_bear_128x128.png",
+    "60": "/assets/img/glowing_bear_60x60.png",
+    "90": "/assets/img/glowing_bear_90x90.png",
+    "32": "/assets/img/favicon.png"
   },
   "installs_allowed_from": [
     "*"


### PR DESCRIPTION
The WebApp installation through firefox wasn't working. Turns out the urls specified in manifest.webapp point all ponit to resources inside the glowing-bear directory, which doesn't exist. 

The only error when launching the webapp is

> Error response
> 
> Error code: 404
> 
> Message: File not found.
> 
> Error code explanation: HTTPStatus.NOT_FOUND - Nothing matches the given URI.