### PR TITLE
Rudimentary Electron (Atom-Shell) support

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -1,0 +1,198 @@
+(function() {
+    'use strict';
+    const electron = require('electron');
+    const app = electron.app;  // Module to control application life.
+    const BrowserWindow = electron.BrowserWindow;  // Module to create native browser window.
+
+    const ipcMain = require('electron').ipcMain;
+    const Menu = require('menu');
+
+    const template = [
+    {
+        label: 'Edit',
+        submenu: [
+        {
+            label: 'Undo',
+            accelerator: 'CmdOrCtrl+Z',
+            role: 'undo'
+        },
+        {
+            label: 'Redo',
+            accelerator: 'Shift+CmdOrCtrl+Z',
+            role: 'redo'
+        },
+        {
+            type: 'separator'
+        },
+        {
+            label: 'Cut',
+            accelerator: 'CmdOrCtrl+X',
+            role: 'cut'
+        },
+        {
+            label: 'Copy',
+            accelerator: 'CmdOrCtrl+C',
+            role: 'copy'
+        },
+        {
+            label: 'Paste',
+            accelerator: 'CmdOrCtrl+V',
+            role: 'paste'
+        },
+        {
+            label: 'Select All',
+            accelerator: 'CmdOrCtrl+A',
+            role: 'selectall'
+        },
+        ]
+    },
+    {
+        label: 'View',
+        submenu: [
+        {
+            label: 'Reload',
+            accelerator: 'CmdOrCtrl+R',
+            click: function(item, focusedWindow) {
+                if (focusedWindow)
+                    focusedWindow.reload();
+            }
+        },
+        {
+            label: 'Toggle Full Screen',
+            accelerator: (function() {
+                if (process.platform == 'darwin')
+                    return 'Ctrl+Command+F';
+                else
+                    return 'F11';
+            })(),
+            click: function(item, focusedWindow) {
+                if (focusedWindow)
+                    focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
+            }
+        },
+        {
+            label: 'Toggle Developer Tools',
+            accelerator: (function() {
+                if (process.platform == 'darwin')
+                    return 'Alt+Command+I';
+                else
+                    return 'Ctrl+Shift+I';
+            })(),
+            click: function(item, focusedWindow) {
+                if (focusedWindow)
+                    focusedWindow.toggleDevTools();
+            }
+        },
+        ]
+    },
+    {
+        label: 'Window',
+        role: 'window',
+        submenu: [
+        {
+            label: 'Minimize',
+            accelerator: 'CmdOrCtrl+M',
+            role: 'minimize'
+        },
+        {
+            label: 'Close',
+            accelerator: 'CmdOrCtrl+W',
+            role: 'close'
+        },
+        ]
+    },
+    {
+        label: 'Help',
+        role: 'help',
+        submenu: [
+        {
+            label: 'Learn More',
+            click: function() { require('electron').shell.openExternal('https://github.com/glowing-bear/glowing-bear') }
+        },
+        ]
+    },
+    ];
+
+    if (process.platform == 'darwin') {
+        var name = require('electron').remote.app.getName();
+        template.unshift({
+            label: name,
+            submenu: [
+            {
+                label: 'About ' + name,
+                role: 'about'
+            },
+            {
+                type: 'separator'
+            },
+            {
+                label: 'Services',
+                role: 'services',
+                submenu: []
+            },
+            {
+                type: 'separator'
+            },
+            {
+                label: 'Hide ' + name,
+                accelerator: 'Command+H',
+                role: 'hide'
+            },
+            {
+                label: 'Hide Others',
+                accelerator: 'Command+Alt+H',
+                role: 'hideothers'
+            },
+            {
+                label: 'Show All',
+                role: 'unhide'
+            },
+            {
+                type: 'separator'
+            },
+            {
+                label: 'Quit',
+                accelerator: 'Command+Q',
+                click: function() { app.quit(); }
+            },
+            ]
+        });
+        // Window menu.
+        template[3].submenu.push(
+                {
+                    type: 'separator'
+                },
+                {
+                    label: 'Bring All to Front',
+                    role: 'front'
+                }
+                );
+    }
+    var menu = Menu.buildFromTemplate(template);
+    Menu.setApplicationMenu(menu);
+
+    // Keep a global reference of the window object, if you don't, the window will
+    // be closed automatically when the JavaScript object is garbage collected.
+    var mainWindow = null;
+
+    app.on('browser-window-focus', function(e, w) {
+        w.webContents.executeJavaScript('setTimeout(function() { document.getElementById("glowingbear").focus(); }, 0);');
+        w.webContents.executeJavaScript('setTimeout(function() { document.getElementById("glowingbear").executeJavaScript("document.getElementById(\\"sendMessage\\").focus();") }, 0);');
+    });
+
+    app.on('ready', function() {
+        mainWindow = new BrowserWindow({width: 1280, height: 800, 'min-width': 1024, 'min-height': 600, 'autoHideMenuBar': true, 'web-security': true, 'java': false, 'icon':'file://'+__dirname + 'assets/img/favicon.png'});
+        mainWindow.loadUrl('file://' + __dirname + '/electron-start.html');
+        /*
+        ipcMain.on('badge', function(event, arg) {
+            app.dock.setBadge(String(arg));
+        });*/
+        mainWindow.on('devtools-opened', function() {
+            mainWindow.webContents.executeJavaScript("document.getElementById('glowingbear').openDevTools();");
+        });
+
+        mainWindow.on('closed', function() {
+            app.quit();
+        });
+    });
+})();

--- a/electron-start.html
+++ b/electron-start.html
@@ -1,0 +1,31 @@
+<html>
+  <head>
+    <script>
+onload = function() {
+  const ipc= require('electron').ipcRenderer;
+
+  var webview = document.getElementById("glowingbear");
+
+  var handleconsole = function(e) {
+    if(e.message.substring(0,7) == "badge: ") {
+      ipc.send('badge', e.message.substring(7));
+    }else{
+      console.log("webview: " + e.message);
+    }
+  }
+  var handlenewwindow = function(e) {
+    require('shell').openExternal(e.url);
+  }
+  var handletitleset = function(e) {
+    document.title = e.title;
+  }
+  webview.addEventListener("console-message", handleconsole);
+  webview.addEventListener("new-window", handlenewwindow);
+  webview.addEventListener("page-title-set", handletitleset);
+}
+    </script>
+  </head>
+  <body>
+    <webview id="glowingbear" src="index.html" style="position:fixed; top:0; left:0; bottom:0; right:0;"></webview>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.6.0",
   "description": "A web client for Weechat",
   "repository": "https://github.com/glowing-bear/glowing-bear",
+  "main": "electron-main.js",
   "license": "GPLv3",
   "devDependencies": {
     "bower": "^1.3.1",
@@ -31,6 +32,8 @@
     "update-webdriver": "webdriver-manager update",
     "preprotractor": "npm run update-webdriver",
     "protractor": "protractor test/protractor-conf.js",
+    "build-electron-windows": "electron-packager . \"Glowing Bear\" --platform=win32 --arch=ia32 --version=0.37.3 --overwrite --icon=assets/img/favicon.ico --asar=true --version-string.FileDescription=\"Glowing Bear\"",
+    "build-electron-darwin": "electron-packager . \"Glowing Bear\" --platform=darwin --arch=x64 --version=0.37.3 --overwrite --asar=true --version-string.FileDescription=\"Glowing Bear\"",
     "update-index-async": "node -e \"require('shelljs/global'); sed('-i', /\\/\\/@@NG_LOADER_START@@[\\s\\S]*\\/\\/@@NG_LOADER_END@@/, '//@@NG_LOADER_START@@\\n' + cat('app/bower_components/angular-loader/angular-loader.min.js') + '\\n//@@NG_LOADER_END@@', 'app/index-async.html');\""
   }
 }


### PR DESCRIPTION
This patch serves as a starting point for making electron based Glowing
Bear builds. Primary motivation is that Mozilla is removing support for
their web runtime, so then Electron is a new way to get standalone
application running outside of browser.

This adds 2 new files that will be the main html and main js for
electron. Those files simply load the rest of the app.

It also adds two new npm run commands to build windows and darwin builds
for electron. Darwin is untested so far.

Bulding packages requires npm package `electron-packager`

There's still some problems with notifications.
And badges for the dock in Darwin is not implemented.
We could also put all keyboard shorcuts in menus.

Thanks to @lukas2511 for some guidance on the wrappers and commands.