### PR TITLE
Imgurhttps

### DIFF
--- a/js/imgur.js
+++ b/js/imgur.js
@@ -71,7 +71,7 @@ weechat.factory('imgur', ['$rootScope', function($rootScope) {
                 if( response.data && response.data.link ) {
 
                     if (callback && typeof(callback) === "function") {
-                        callback(response.data.link);
+                        callback(response.data.link.replace(/^http:/, "https:"));
                     }
 
                 } else {


### PR DESCRIPTION
When using the Imgur upload tool (which uses HTTPS), the API currently responds with an HTTP URL. We should share it as an HTTPS URL.