### PR TITLE
Make the settings close button more visible for dark themes

### DIFF
--- a/css/themes/dark.css
+++ b/css/themes/dark.css
@@ -160,6 +160,15 @@ input[type=text], input[type=password], #sendMessage, .badge, .btn-send, .btn-se
     border-bottom-color: #121212;
 }
 
+button.close {
+    color: #ddd;
+    opacity: 1;
+}
+
+button.close:hover {
+    color: #ddd;
+}
+
 /****************************/
 /* Weechat colors and style */
 /****************************/


### PR DESCRIPTION
Before: 
<img width="686" alt="screen shot 2016-04-08 at 4 54 18 pm" src="https://cloud.githubusercontent.com/assets/1652595/14397295/967c6d72-fdaa-11e5-97a0-cc868e0c4150.png">

After:
<img width="674" alt="screen shot 2016-04-08 at 4 54 03 pm" src="https://cloud.githubusercontent.com/assets/1652595/14397299/9a036c0c-fdaa-11e5-8225-0fb2d0b9515b.png">
