### PR TITLE
more readable messages with increased line-height

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -33,7 +33,6 @@ td.prefix {
     border-right: 1px solid #444;
 }
 td.message {
-    line-height: 1.4;
     overflow: hidden;
     vertical-align: top;
     width: 100%;

--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -33,6 +33,7 @@ td.prefix {
     border-right: 1px solid #444;
 }
 td.message {
+    line-height: 1.4;
     overflow: hidden;
     vertical-align: top;
     width: 100%;

--- a/css/themes/dark-spacious.css
+++ b/css/themes/dark-spacious.css
@@ -1,0 +1,5 @@
+@import "dark.css";
+
+td.message {
+    line-height: 1.4;
+}


### PR DESCRIPTION
Increasing the message `line-height` makes them a bit more readable for me.

I could foresee however that someone might prefer the current more compact setting of the messages. If that is so, I could create a setting that will switch the `line-height`, so the increased line-height could be by default or an opt-in setting.