### PR TITLE
Bufferline timestamps now try to detect locale

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,7 +289,7 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
             <tr class="bufferline">
               <td class="time">
                 <span class="date" ng-class="::{'repeated-time': bufferline.shortTime==bufferlines[$index-1].shortTime}">
-                  <span class="cof-chat_time cob-chat_time coa-chat_time" ng-bind="::(bufferline.date|date:'HH')"></span><span class="cof-chat_time_delimiters cob-chat_time_delimiters coa-chat_time_delimiters">:</span><span class="cof-chat_time cob-chat_time coa-chat_time" ng-bind="::(bufferline.date|date:'mm')"></span><span class="seconds"><span class="cof-chat_time_delimiters cob-chat_time_delimiters coa-chat_time_delimiters">:</span><span class="cof-chat_time cob-chat_time coa-chat_time" ng-bind="::(bufferline.date|date:'ss')"></span></span>
+                  <span class="cof-chat_time cob-chat_time coa-chat_time timestamp-no-seconds" ng-bind-html="::bufferline.formattedTime"></span>
                 </span>
               </td>
               <td class="prefix"><a ng-click="addMention(bufferline.prefix)"><span class="hidden-bracket">&lt;</span><span ng-repeat="part in ::bufferline.prefix" ng-class="::part.classes" ng-bind="::part.text|prefixlimit:25"></span><span class="hidden-bracket">&gt;</span></a></td><!--

--- a/js/models.js
+++ b/js/models.js
@@ -347,6 +347,24 @@ models.service('models', ['$rootScope', '$filter', function($rootScope, $filter)
         var buffer = message.buffer;
         var date = message.date;
         var shortTime = $filter('date')(date, 'HH:mm');
+        var formattedTime = "";
+
+        if ($rootScope.supports_formatting_date) {
+          formattedTime = date.toLocaleTimeString([], {hour: "2-digit",
+                                                 minute: "2-digit",
+                                                 second: "2-digit"});
+        } else {
+          formattedTime = $filter('date')(date, 'HH:mm:ss');
+        }
+
+        formattedTime = formattedTime.replace(/ /g, "&nbsp;");
+        // If in 12h time the hour field has only one number, zero pad it
+        formattedTime = formattedTime.replace(/^(\d)(:|\.)/, '0$1$2');
+        // Wrap the first time separator in a span
+        formattedTime = formattedTime.replace(/(:|\.)/, '<span class="cof-chat_time_delimiters cob-chat_time_delimiters coa-chat_time_delimiters">$1</span>');
+        // Wrap the second time separator and seconds field in another span
+        // so that we can easily hide seconds using a CSS selector
+        formattedTime = formattedTime.replace(/(\d\d)(:|\.)(\d\d)/, '$1<span class="seconds"><span class="cof-chat_time_delimiters cob-chat_time_delimiters coa-chat_time_delimiters">$2</span>$3</span>');
 
         var prefix = parseRichText(message.prefix);
         var tags_array = message.tags_array;
@@ -370,6 +388,7 @@ models.service('models', ['$rootScope', '$filter', function($rootScope, $filter)
             content: content,
             date: date,
             shortTime: shortTime,
+            formattedTime: formattedTime,
             buffer: buffer,
             tags: tags_array,
             highlight: highlight,


### PR DESCRIPTION
Follows the same pattern as `injectDateChangeMessageIfNeeded` in file `js/handlers.js`, roughly.

Adds a bit more complexity to figure out what the user's locale time string is.

Also, moves a little bit of code complexity from index.html to js/models.js . The reasoning behind this is the format of the time string will only be figured out when javascript code is being executed, and if we want to apply a different style to the time separators as we do now, then we'll have to do that in the JS code.

Prototype PR, so for sure let me know if there's anything to change. For example, [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString#Performance) suggests I can use `Intl.DateTimeFormat` something or other to get better performance for large amounts of dates.

Thoughts?