### PR TITLE
Allow trailing slash at end of gist

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -435,11 +435,11 @@ plugins.factory('userPlugins', function() {
 
     // Embed GitHub gists
     var gistPlugin = new UrlPlugin('Gist', function(url) {
-        var regexp = /^https:\/\/gist\.github.com\/[^.?]+\/?/i;
+        var regexp = /^(https:\/\/gist\.github.com\/[^.?]+)\/?/i;
         var match = url.match(regexp);
         if (match) {
             // get the URL from the match to trim away pseudo file endings and request parameters
-            url = match[0] + '.json';
+            url = match[1] + '.json';
             // load gist asynchronously -- return a function here
             return function() {
                 var element = this.getElement();

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -435,7 +435,7 @@ plugins.factory('userPlugins', function() {
 
     // Embed GitHub gists
     var gistPlugin = new UrlPlugin('Gist', function(url) {
-        var regexp = /^https:\/\/gist\.github.com\/[^.?]+/i;
+        var regexp = /^https:\/\/gist\.github.com\/[^.?]+\/?/i;
         var match = url.match(regexp);
         if (match) {
             // get the URL from the match to trim away pseudo file endings and request parameters

--- a/test/unit/plugins.js
+++ b/test/unit/plugins.js
@@ -134,6 +134,7 @@ describe('filter', function() {
             expectTheseMessagesToContain([
                 'https://gist.github.com/lorenzhs/e8c1a7d56fa170320eb8',
                 'https://gist.github.com/e8c1a7d56fa170320eb8',
+                'https://gist.github.com/bgrins/6595824/',
             ],
             'Gist',
             plugins);


### PR DESCRIPTION
Just a one-liner that lets the gist plugin load URL that requires a trailing slash.