### PR TITLE
fix nick completion within brackets #781

### DIFF
--- a/js/irc-utils.js
+++ b/js/irc-utils.js
@@ -44,7 +44,7 @@ IrcUtils.service('IrcUtils', [function() {
         var foundNick = null;
 
         nickList.some(function(nick) {
-            if (nick.toLowerCase().search(candidate.toLowerCase()) === 0) {
+            if (nick.toLowerCase().indexOf(candidate.toLowerCase()) === 0) {
                 // found!
                 foundNick = nick;
                 return true;
@@ -72,7 +72,7 @@ IrcUtils.service('IrcUtils', [function() {
         // collect matching nicks
         for (var i = 0; i < nickList.length; ++i) {
             var lcNick = nickList[i].toLowerCase();
-            if (lcNick.search(escapeRegExp(lcIterCandidate)) === 0) {
+            if (lcNick.indexOf(lcIterCandidate) === 0) {
                 matchingNicks.push(nickList[i]);
                 if (lcCurrentNick === lcNick) {
                     at = matchingNicks.length - 1;
@@ -158,7 +158,7 @@ IrcUtils.service('IrcUtils', [function() {
         m = beforeCaret.match(/^([a-zA-Z0-9_\\\[\]{}^`|-]+)$/);
         if (m) {
             // try completing
-            newNick = _completeSingleNick(escapeRegExp(m[1]), searchNickList);
+            newNick = _completeSingleNick(m[1], searchNickList);
             if (newNick === null) {
                 // no match
                 return ret;


### PR DESCRIPTION
Changed nick completion to use indexOf instead of search, which makes sense to me because the regex was being escaped anyway.

escapeRegExp is now unused but I left it there in case it's needed in the future. For example, it seems that custom suffix support is possible, and that will need to be escaped.

Manual testing, with cursor at the end of the buffer (note the leading space)
- " [Gib]" no longer tab-completes to Gibstick
- " [A-Za-z]" no longer tab-completes to some nick (I don't know why it picks what it does -- ordering of the nicklist?)
- " [a]" no longer tab-completes to some nick (see above)
- " [fo" will now tab-complete to "[foobar]" if a user "[foobar]" is in the channel, and no longer gives `Error: unterminated character class`

Addresses #781 