### PR TITLE
Update plugin.js

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -400,7 +400,7 @@ plugins.factory('userPlugins', function() {
       * Asciinema plugin
      */
     var asciinemaPlugin = new UrlPlugin('ascii cast', function(url) {
-        var regexp = /^https?:\/\/(?:www\.)?asciinema.org\/a\/(\d+)/i,
+        var regexp = /^https?:\/\/(?:www\.)?asciinema.org\/a\/(.*[0-9a-z])/i,
             match = url.match(regexp);
         if (match) {
             var id = match[1];

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -400,7 +400,7 @@ plugins.factory('userPlugins', function() {
       * Asciinema plugin
      */
     var asciinemaPlugin = new UrlPlugin('ascii cast', function(url) {
-        var regexp = /^https?:\/\/(?:www\.)?asciinema.org\/a\/(.*[0-9a-z])/i,
+        var regexp = /^https?:\/\/(?:www\.)?asciinema.org\/a\/([0-9a-z]+)/i,
             match = url.match(regexp);
         if (match) {
             var id = match[1];


### PR DESCRIPTION
The Asciinema cast plugin regex was faulty. Casts can have /[a-z]/ characters, not only digits.
Here is a test cast for you to run: https://asciinema.org/a/29qfl1dwsgd25o91nfv3dvvbn