### PR TITLE
Periodic hotlist sync. Fixes #692

### DIFF
--- a/js/connection.js
+++ b/js/connection.js
@@ -151,21 +151,33 @@ weechat.factory('connection',
                     _requestHotlist().then(function(hotlist) {
                         handlers.handleHotlistInfo(hotlist);
 
-                        if (successCallback) {
-                            successCallback();
-                        }
                     });
+                    // Schedule hotlist syncing every so often so that this
+                    // client will have unread counts (mostly) in sync with
+                    // other clients or terminal usage directly.
+                    setInterval(function() {
+                        if ($rootScope.connected) {
+                            _requestHotlist().then(function(hotlist) {
+                                handlers.handleHotlistInfo(hotlist);
+
+                            });
+                        }
+                    }, 60000); // Sync hotlist every 60 second
+
 
                     // Fetch weechat time format for displaying timestamps
                     fetchConfValue('weechat.look.buffer_time_format',
                                    function() {
+                                       // Will set models.wconfig['weechat.look.buffer_time_format']
                                        _parseWeechatTimeFormat();
-                                   });
-                    // Will set models.wconfig['weechat.look.buffer_time_format']
+                   });
 
                     _requestSync();
                     $log.info("Connected to relay");
                     $rootScope.connected = true;
+                    if (successCallback) {
+                        successCallback();
+                    }
                 },
                 function() {
                     handleWrongPassword();


### PR DESCRIPTION
There is a bug in WeeChat when hdata is null, which happens when the
hotlist is empty (meaning all buffers are read). Our websocket callback
machinery expects every command with id to return data, so this code in
current versions of WeeChat will lead to a slow leak. But I think lots
of things in our code will do this already so I'm not entirely sure it's
too problematic to let this patch go by.

We could use infolists instead of hdata, but that is cumbersome to parse
and less performant for WeeChat, and sends more data over the wire.

I propose we make a separate attempt at cleaning up the callbacks. Since
we store time on them we could have a cleanuptask that looks through
them and deletes old callbacks. Maybe @dcormier could have a look?