### PR TITLE
allow browser to use https for pastebin embeds

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -457,11 +457,11 @@ plugins.factory('userPlugins', function() {
     });
 
     var pastebinPlugin = new UrlPlugin('Pastebin', function(url) {
-        var regexp = /^http:\/\/pastebin.com\/([^.?]+)/i;
+        var regexp = /^https?:\/\/pastebin.com\/([^.?]+)/i;
         var match = url.match(regexp);
         if (match) {
             var id = match[1],
-                embedurl = "http://pastebin.com/embed_iframe/" + id,
+                embedurl = "//pastebin.com/embed_iframe/" + id,
                 element = angular.element('<iframe></iframe>')
                                  .attr('src', embedurl)
                                  .attr('width', '100%')


### PR DESCRIPTION
Pastebin embeds were coded to http:// and are blocked by Chrome when using an https:// g-b. Pastebin supports HTTPS for embed_iframe urls so easy enough fix.