### PR TITLE
Add underscore to youtube regex

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -206,7 +206,7 @@ plugins.factory('userPlugins', function() {
      * See: https://developers.google.com/youtube/player_parameters
      */
     var youtubePlugin = new UrlPlugin('YouTube video', function(url) {
-        var regex = /(?:youtube.com|youtu.be)\/(?:v\/|embed\/|watch(?:\?v=|\/))?([a-zA-Z0-9-]+)/i,
+        var regex = /(?:youtube.com|youtu.be)\/(?:v\/|embed\/|watch(?:\?v=|\/))?([a-zA-Z0-9_-]+)/i,
             match = url.match(regex);
 
         if (match){


### PR DESCRIPTION
Youtube links can have underscores, like `https://www.youtube.com/watch?v=Xtrsh4U_GCY`. 

Should I add a unit test to check and make sure that videos with _ are recognized? Doesn't look like there's an infrastructure in place in the tests to test that the entire token is the string, but I can add it if you want.