### PR TITLE
Able to resume previous buffer

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,12 @@
                     </label>
                   </div>
                   <div class="checkbox">
+                    <label class="control-label" for="resumeBuffer">
+                        <input type="checkbox" id="resumeBuffer" ng-model="settings.resumeBuffer">
+                        Resume last buffer
+                    </label>
+                  </div>
+                  <div class="checkbox">
                     <label class="control-label" for="ssl">
                       <input type="checkbox" id="ssl" ng-model="settings.ssl">
                       Encryption. Read instructions for help

--- a/js/connection.js
+++ b/js/connection.js
@@ -19,7 +19,7 @@ weechat.factory('connection',
     var locked = false;
 
     // Takes care of the connection and websocket hooks
-    var connect = function (host, port, passwd, ssl, noCompression, successCallback, failCallback) {
+    var connect = function (host, port, passwd, ssl, noCompression, bufferToStart, successCallback, failCallback) {
         $rootScope.passwordError = false;
         connectionData = [host, port, passwd, ssl, noCompression];
         var proto = ssl ? 'wss' : 'ws';
@@ -145,7 +145,7 @@ weechat.factory('connection',
                     // Connection is successful
                     // Send all the other commands required for initialization
                     _requestBufferInfos().then(function(bufinfo) {
-                        handlers.handleBufferInfo(bufinfo);
+                        handlers.handleBufferInfo(bufinfo, bufferToStart);
                     });
 
                     _requestHotlist().then(function(hotlist) {

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -45,6 +45,8 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         'enableJSEmoji': (utils.isMobileUi() ? false : true),
         'enableMathjax': false,
         'customCSS': '',
+        "resumeBuffer":false,
+        "activeBuffer":"",
     });
     $scope.settings = settings;
 
@@ -159,6 +161,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
 
         $scope.bufferlines = ab.lines;
         $scope.nicklist = ab.nicklist;
+        $scope.settings.activeBuffer = ab.id;
 
         // Send a request for the nicklist if it hasn't been loaded yet
         if (!ab.nicklistRequested()) {
@@ -594,7 +597,10 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         $rootScope.bufferBottom = true;
         $scope.connectbutton = 'Connecting';
         $scope.connectbuttonicon = 'glyphicon-refresh glyphicon-spin';
-        connection.connect(settings.host, settings.port, $scope.password, settings.ssl);
+        if(settings.resumeBuffer) {
+            var bufferToStart = settings.activeBuffer;
+        }
+        connection.connect(settings.host, settings.port, $scope.password, settings.ssl, null, bufferToStart);
     };
     $scope.disconnect = function() {
         $scope.connectbutton = 'Connect';

--- a/js/handlers.js
+++ b/js/handlers.js
@@ -175,7 +175,7 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
         }
     };
 
-    var handleBufferInfo = function(message) {
+    var handleBufferInfo = function(message, bufferToStart) {
         var bufferInfos = message.objects[0].content;
         // buffers objects
         for (var i = 0; i < bufferInfos.length ; i++) {
@@ -188,7 +188,10 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
                 buffer = new models.Buffer(bufferInfos[i]);
                 models.addBuffer(buffer);
                 // Switch to first buffer on startup
-                if (i === 0) {
+                if (i === 0 && bufferToStart === undefined) {
+                    models.setActiveBuffer(buffer.id);
+                }
+                else if(buffer.id === bufferToStart){
                     models.setActiveBuffer(buffer.id);
                 }
             }


### PR DESCRIPTION
This will add the ability to return the the last viewed buffer upon connection.  

When I use glowing-bear on IOS it often closes the connection when switching applications.  I found it annoying to have to choose the buffer every time I launched the application.  This stores the activebuffer in the localstorage and provides a setting that allows the application to automatically set the current buffer back on connection.