### PR TITLE
Able to resume buffer

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
     <script type="text/javascript" src="js/inputbar.js"></script>
     <script type="text/javascript" src="js/plugin-directive.js"></script>
     <script type="text/javascript" src="js/websockets.js"></script>
+    <script type="text/javascript" src="js/bufferResume.js"></script>
     <script type="text/javascript" src="js/models.js"></script>
     <script type="text/javascript" src="js/plugins.js"></script>
     <script type="text/javascript" src="js/imgur.js"></script>

--- a/js/bufferResume.js
+++ b/js/bufferResume.js
@@ -1,0 +1,56 @@
+
+/*
+ * This file contains the service used to record the last 
+ * accessed buffer and return to it when reconnecting to 
+ * the relay.
+ */
+(function() {
+'use strict';
+
+var bufferResume = angular.module('bufferResume', []);
+
+bufferResume.service('bufferResume', ['settings', function(settings) {
+    var resumer = {};
+    var key = settings.host + ":" + settings.port;
+
+    // Hold the status that we were able to find the previously accessed buffer
+    //   and reload it.  If we cannot, we'll need to know so we can load the default
+    var hasResumed = false;
+
+    // Store the current buffer as having been accessed.  We can later retrieve it and compare 
+    //   we recieve info from weechat to determine if we should switch to it.
+    resumer.record = function(activeBuffer) {
+        var subSetting = settings.currentlyViewedBuffers;
+        subSetting[key] = activeBuffer.id;
+        settings.currentlyViewedBuffers = subSetting;
+    };
+
+    // See if the requested buffer information matches the last recorded access.  If so, 
+    //   the handler should switch to this buffer.
+    resumer.shouldResume = function(buffer) {
+        var savedBuffer = settings.currentlyViewedBuffers[key];
+        if (!savedBuffer) { return false; }
+
+        if (!hasResumed) {
+            if (savedBuffer === buffer.id) {
+                hasResumed = true;
+                return true; 
+            }
+            return false;
+        }
+    };
+
+    // The handler will ask for this after loading all infos.  If it was unable to find a buffer
+    //   it will need to know so it can pick the default buffer.
+    resumer.wasAbleToResume = function() {
+        return hasResumed;
+    };
+
+    // Clear out the recorded info.  Maybe we'll do this when the user chooses to disconnect?  
+    resumer.clear = function() {
+        record(undefined);
+    };
+
+    return resumer;
+}]);
+})();

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -1,7 +1,7 @@
 (function() {
 'use strict';
 
-var weechat = angular.module('weechat', ['ngRoute', 'localStorage', 'weechatModels', 'plugins', 'IrcUtils', 'ngSanitize', 'ngWebsockets', 'ngTouch'], ['$compileProvider', function($compileProvider) {
+var weechat = angular.module('weechat', ['ngRoute', 'localStorage', 'weechatModels', 'bufferResume', 'plugins', 'IrcUtils', 'ngSanitize', 'ngWebsockets', 'ngTouch'], ['$compileProvider', function($compileProvider) {
     // hacky way to be able to find out if we're in debug mode
     weechat.compileProvider = $compileProvider;
 }]);
@@ -12,8 +12,8 @@ weechat.config(['$compileProvider', function ($compileProvider) {
     }
 }]);
 
-weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout', '$log', 'models', 'connection', 'notifications', 'utils', 'settings',
-    function ($rootScope, $scope, $store, $timeout, $log, models, connection, notifications, utils, settings) {
+weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout', '$log', 'models', 'bufferResume', 'connection', 'notifications', 'utils', 'settings',
+    function ($rootScope, $scope, $store, $timeout, $log, models, bufferResume, connection, notifications, utils, settings) {
 
     window.openBuffer = function(channel) {
         $scope.openBuffer(channel);
@@ -45,6 +45,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         'enableJSEmoji': (utils.isMobileUi() ? false : true),
         'enableMathjax': false,
         'customCSS': '',
+        "currentlyViewedBuffers":{},
     });
     $scope.settings = settings;
 

--- a/js/handlers.js
+++ b/js/handlers.js
@@ -3,7 +3,7 @@
 
 var weechat = angular.module('weechat');
 
-weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notifications', function($rootScope, $log, models, plugins, notifications) {
+weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notifications', 'bufferResume', function($rootScope, $log, models, plugins, notifications, bufferResume) {
 
     var handleVersionInfo = function(message) {
         var content = message.objects[0].content;
@@ -188,10 +188,16 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
                 buffer = new models.Buffer(bufferInfos[i]);
                 models.addBuffer(buffer);
                 // Switch to first buffer on startup
-                if (i === 0) {
+                var shouldResume = bufferResume.shouldResume(buffer);
+                if(shouldResume){
                     models.setActiveBuffer(buffer.id);
                 }
             }
+        }
+        // If there was no buffer to autmatically load, go to the first one.
+        if (!bufferResume.wasAbleToResume()) {
+            var first = bufferInfos[0].pointers[0];
+            models.setActiveBuffer(first);
         }
     };
 

--- a/js/models.js
+++ b/js/models.js
@@ -7,7 +7,7 @@
 
 var models = angular.module('weechatModels', []);
 
-models.service('models', ['$rootScope', '$filter', function($rootScope, $filter) {
+models.service('models', ['$rootScope', '$filter', 'bufferResume', function($rootScope, $filter, bufferResume) {
     // WeeChat version
     this.version = null;
 
@@ -547,6 +547,7 @@ models.service('models', ['$rootScope', '$filter', function($rootScope, $filter)
 
         $rootScope.$emit('activeBufferChanged', unreadSum);
         $rootScope.$emit('notificationChanged');
+        bufferResume.record(activeBuffer);
         return true;
     };
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "GPLv3",
   "devDependencies": {
     "bower": "^1.3.1",
-    "electron-packager": "^6.0.0",
+    "electron-packager": "^7.0.0",
     "http-server": "^0.6.1",
     "jasmine-core": "^2.4.1",
     "jshint": "^2.5.2",
@@ -16,14 +16,14 @@
     "karma-jasmine": "^0.3.6",
     "karma-junit-reporter": "^0.2.2",
     "karma-phantomjs-launcher": "^0.2.1",
-    "phantomjs": "^1.9.19",
+    "phantomjs-prebuilt": "^2.1.1",
     "protractor": "~0.20.1",
     "shelljs": "^0.2.6",
     "uglify-js": "^2.4"
   },
   "scripts": {
     "postinstall": "bower install",
-    "minify": " uglifyjs js/localstorage.js js/weechat.js js/irc-utils.js js/glowingbear.js js/settings.js js/utils.js js/notifications.js js/filters.js js/handlers.js js/connection.js js/file-change.js js/imgur-drop-directive.js js/whenscrolled-directive.js js/inputbar.js js/plugin-directive.js js/websockets.js js/models.js js/plugins.js js/imgur.js -c -m --screw-ie8 -o min.js --source-map min.map",
+    "minify": " uglifyjs js/localstorage.js js/weechat.js js/irc-utils.js js/glowingbear.js js/settings.js js/utils.js js/notifications.js js/filters.js js/handlers.js js/connection.js js/file-change.js js/imgur-drop-directive.js js/whenscrolled-directive.js js/inputbar.js js/plugin-directive.js js/websockets.js js/models.js js/bufferResume.js js/plugins.js js/imgur.js -c -m --screw-ie8 -o min.js --source-map min.map",
     "prestart": "npm install",
     "start": "http-server -a localhost -p 8000",
     "pretest": "npm install",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -22,6 +22,7 @@ module.exports = function(config){
       'js/plugin-directive.js',
       'js/websockets.js',
       'js/models.js',
+      'js/bufferResume.js',
       'js/plugins.js',
       'test/unit/**/*.js'
     ],


### PR DESCRIPTION
This will add the ability to return the the last viewed buffer upon connection.  

When I use glowing-bear on IOS it often closes the connection when switching applications.  I found it annoying to have to choose the buffer every time I launched the application.  This stores the activebuffer in the localstorage and provides a setting that allows the application to automatically set the current buffer back on connection.