### PR TITLE
Fix bug where disconnecting using the 'power' button, resume acted strange

### DIFF
--- a/js/bufferResume.js
+++ b/js/bufferResume.js
@@ -47,8 +47,8 @@ bufferResume.service('bufferResume', ['settings', function(settings) {
     };
 
     // Clear out the recorded info.  Maybe we'll do this when the user chooses to disconnect?  
-    resumer.clear = function() {
-        record(undefined);
+    resumer.reset = function() {
+        hasResumed = false;
     };
 
     return resumer;

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -260,6 +260,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         $rootScope.$emit('notificationChanged');
         $scope.connectbutton = 'Connect';
         $scope.connectbuttonicon = 'glyphicon-chevron-right';
+        bufferResume.reset();
     });
     $scope.connectbutton = 'Connect';
     $scope.connectbuttonicon = 'glyphicon-chevron-right';
@@ -600,6 +601,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     $scope.disconnect = function() {
         $scope.connectbutton = 'Connect';
         $scope.connectbuttonicon = 'glyphicon-chevron-right';
+        bufferResume.reset();
         connection.disconnect();
     };
     $scope.reconnect = function() {


### PR DESCRIPTION
We needed to "reset" the state of the resumer when disconnecting via the power button -- otherwise it would thing it had already done its job.