### PR TITLE
highlight buffers with unread messages

### DIFF
--- a/css/themes/dark.css
+++ b/css/themes/dark.css
@@ -2138,3 +2138,11 @@ button.close:hover {
 
 
 
+.buffername {
+    color: #888;
+}
+
+.buffername.active {
+    color: white;
+    font-weight: bold;
+}

--- a/css/themes/dark.css
+++ b/css/themes/dark.css
@@ -2142,7 +2142,7 @@ button.close:hover {
     color: #888;
 }
 
-.buffername.active {
+.buffername.unread {
     color: white;
     font-weight: bold;
 }

--- a/index.html
+++ b/index.html
@@ -275,7 +275,7 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
             <a ng-click="setActiveBuffer(buffer.id)" title="{{ buffer.fullName }}" href="#">
               <span class="badge pull-right" ng-class="{'danger': buffer.notification}" ng-if="buffer.notification || buffer.unread" ng-bind="buffer.notification || buffer.unread"></span>
               <span class="buffer-quick-key">{{ buffer.$quickKey }}</span>
-              <span class="buffername">{{ buffer.trimmedName || buffer.fullName }}</span>
+              <span class="buffername" ng-class="{'active': buffer.notification || buffer.unread}">{{ buffer.trimmedName || buffer.fullName }}</span>
             </a>
           </li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -275,7 +275,7 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
             <a ng-click="setActiveBuffer(buffer.id)" title="{{ buffer.fullName }}" href="#">
               <span class="badge pull-right" ng-class="{'danger': buffer.notification}" ng-if="buffer.notification || buffer.unread" ng-bind="buffer.notification || buffer.unread"></span>
               <span class="buffer-quick-key">{{ buffer.$quickKey }}</span>
-              <span class="buffername" ng-class="{'active': buffer.notification || buffer.unread}">{{ buffer.trimmedName || buffer.fullName }}</span>
+              <span class="buffername" ng-class="{'unread': buffer.notification || buffer.unread}">{{ buffer.trimmedName || buffer.fullName }}</span>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
This adds a new css class `.active` to buffers which have unread messages. I've also updated the dark theme to make use of it. Here's how it looks like before/after:

![highlight-buffers](https://cloud.githubusercontent.com/assets/1065521/19221153/40c71f80-8e46-11e6-9768-7b834acc0bde.png)
