### PR TITLE
Change .footer positioning so that it does not jump on iOS

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -352,8 +352,8 @@ td.time {
 }
 
 .footer {
-    position: fixed;
-    bottom: 0;
+    position: relative;
+    bottom: 35px;
     height: 35px;
     width: 100%;
     -webkit-transition:0.2s ease-in-out all;


### PR DESCRIPTION
After testing on firefox turns out it's broken, there's now 35px of free space at the bottom. In other browsers I've tested (Chrome, Safari on iOS, and even Microsoft Edge) it works fine however. Not sure what to do here.