### PR TITLE
Implement repeated-prefix, Fix #844

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,7 +304,7 @@ $ openssl req -nodes -newkey rsa:4096 -keyout relay.pem -x509 -days 365 -out rel
                   <span class="cof-chat_time cob-chat_time coa-chat_time" ng-bind-html="::bufferline.formattedTime"></span>
                 </span>
               </td>
-              <td class="prefix"><a ng-click="addMention(bufferline.prefix)"><span class="hidden-bracket">&lt;</span><span ng-repeat="part in ::bufferline.prefix" ng-class="::part.classes" ng-bind="::part.text|prefixlimit:25"></span><span class="hidden-bracket">&gt;</span></a></td><!--
+              <td class="prefix"><span ng-class="::{'repeated-prefix': bufferline.prefixtext==bufferlines[$index-1].prefixtext}"><a ng-click="addMention(bufferline.prefix)"><span class="hidden-bracket">&lt;</span><span ng-repeat="part in ::bufferline.prefix" ng-class="::part.classes" ng-bind="::part.text|prefixlimit:25"></span><span class="hidden-bracket">&gt;</span></a></span></td><!--
            --><td class="message"><!--
              --><div ng-repeat="metadata in ::bufferline.metadata" plugin data="::metadata"></div><!--
              --><span ng-repeat="part in ::bufferline.content" class="text" ng-class="::part.classes.concat(['line-' + part.$$hashKey.replace(':','_')])" ng-bind-html="::part.text | linky:'_blank' | DOMfilter:'irclinky' | DOMfilter:'emojify':settings.enableJSEmoji | DOMfilter:'inlinecolour' | DOMfilter:'latexmath':('.line-' + part.$$hashKey.replace(':','_')):settings.enableMathjax"></span>

--- a/js/models.js
+++ b/js/models.js
@@ -365,12 +365,17 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
             });
         }
 
+        var prefixtext = "";
+        for (var pti = 0; pti < prefix.length; ++pti) {
+            prefixtext += prefix[pti].text;
+        }
+
         var rtext = "";
         for (var i = 0; i < content.length; ++i) {
             rtext += content[i].text;
         }
 
-       return {
+        return {
             prefix: prefix,
             content: content,
             date: date,
@@ -380,6 +385,7 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
             tags: tags_array,
             highlight: highlight,
             displayed: displayed,
+            prefixtext: prefixtext,
             text: rtext
 
         };


### PR DESCRIPTION
Fix #844 

Related to #605 , but not the same as it allows conditional styling in CSS (ie. one can suppress duplicate prefixes in desktop layout but show them in mobile layout).