### PR TITLE
better swipe handling and nicklist behaviour on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,7 +280,7 @@ npm run build-electron-{windows, darwin, linux}</pre>
           </a>
         </div>
       </div>
-      <div id="sidebar" data-state="visible" ng-swipe-left="hideSidebar()" ng-swipe-disable-mouse class="vertical-line">
+      <div id="sidebar" data-state="visible" ng-swipe-left="swipeLeft($event)" class="vertical-line">
         <ul class="nav nav-pills nav-stacked" ng-class="{'indented': (predicate === 'serverSortKey'), 'showquickkeys': showQuickKeys, 'showjumpkeys': showJumpKeys}">
           <li class="bufferfilter">
             <form role="form">
@@ -310,8 +310,8 @@ npm run build-electron-{windows, darwin, linux}</pre>
           </li>
         </ul>
       </div>
-      <div id="bufferlines" class="favorite-font" ng-swipe-right="showSidebar()" ng-swipe-left="hideSidebar()" ng-swipe-disable-mouse ng-class="{'withnicklist': showNicklist}" when-scrolled="infiniteScroll()" imgur-drop>
-        <div id="nicklist" ng-if="showNicklist" ng-swipe-right="closeNick()" ng-swipe-disable-mouse class="vertical-line-left">
+      <div id="bufferlines" class="favorite-font" ng-swipe-right="swipeRight($event)" ng-swipe-left="swipeLeft($event)" ng-class="{'withnicklist': showNicklist}" when-scrolled="infiniteScroll()" imgur-drop>
+        <div id="nicklist" ng-if="showNicklist" ng-swipe-right="closeNick()" class="vertical-line-left">
           <ul class="nicklistgroup list-unstyled" ng-repeat="group in nicklist">
             <li ng-repeat="nick in group.nicks|orderBy:'name'">
               <a ng-click="openBuffer(nick.name)"><span ng-class="::nick.prefixClasses" ng-bind="::nick.prefix"></span><span ng-class="::nick.nameClasses" ng-bind="::nick.name"></span></a>
@@ -437,7 +437,7 @@ npm run build-electron-{windows, darwin, linux}</pre>
                   </div>
                 </form>
               </li>
-              <li>
+              <li ng-if="!isMobileUi()">
                 <form class="form-inline" role="form">
                   <div class="checkbox">
                     <label>

--- a/index.html
+++ b/index.html
@@ -437,6 +437,16 @@ npm run build-electron-{windows, darwin, linux}</pre>
                   </div>
                 </form>
               </li>
+              <li ng-if="isMobileUi()">
+                <form class="form-inline" role="form">
+                  <div class="checkbox">
+                    <label>
+                      <input type="checkbox" ng-model="settings.alwaysnicklist">
+                      Always show nicklist
+                    </label>
+                  </div>
+                </form>
+              </li>
               <li ng-if="!isMobileUi()">
                 <form class="form-inline" role="form">
                   <div class="checkbox">

--- a/index.html
+++ b/index.html
@@ -280,7 +280,7 @@ npm run build-electron-{windows, darwin, linux}</pre>
           </a>
         </div>
       </div>
-      <div id="sidebar" data-state="visible" ng-swipe-left="swipeLeft($event)" class="vertical-line">
+      <div id="sidebar" data-state="visible" ng-swipe-left="swipeLeft()" ng-swipe-disable-mouse class="vertical-line">
         <ul class="nav nav-pills nav-stacked" ng-class="{'indented': (predicate === 'serverSortKey'), 'showquickkeys': showQuickKeys, 'showjumpkeys': showJumpKeys}">
           <li class="bufferfilter">
             <form role="form">
@@ -310,8 +310,8 @@ npm run build-electron-{windows, darwin, linux}</pre>
           </li>
         </ul>
       </div>
-      <div id="bufferlines" class="favorite-font" ng-swipe-right="swipeRight($event)" ng-swipe-left="swipeLeft($event)" ng-class="{'withnicklist': showNicklist}" when-scrolled="infiniteScroll()" imgur-drop>
-        <div id="nicklist" ng-if="showNicklist" ng-swipe-right="closeNick()" class="vertical-line-left">
+      <div id="bufferlines" class="favorite-font" ng-swipe-right="swipeRight()" ng-swipe-left="swipeLeft()" ng-swipe-disable-mouse ng-class="{'withnicklist': showNicklist}" when-scrolled="infiniteScroll()" imgur-drop>
+        <div id="nicklist" ng-if="showNicklist" ng-swipe-right="swipeRight()" ng-swipe-disable-mouse class="vertical-line-left">
           <ul class="nicklistgroup list-unstyled" ng-repeat="group in nicklist">
             <li ng-repeat="nick in group.nicks|orderBy:'name'">
               <a ng-click="openBuffer(nick.name)"><span ng-class="::nick.prefixClasses" ng-bind="::nick.prefix"></span><span ng-class="::nick.nameClasses" ng-bind="::nick.name"></span></a>

--- a/index.html
+++ b/index.html
@@ -437,7 +437,7 @@ npm run build-electron-{windows, darwin, linux}</pre>
                   </div>
                 </form>
               </li>
-              <li ng-if="isMobileUi()">
+              <li class="mobile">
                 <form class="form-inline" role="form">
                   <div class="checkbox">
                     <label>
@@ -447,7 +447,7 @@ npm run build-electron-{windows, darwin, linux}</pre>
                   </div>
                 </form>
               </li>
-              <li ng-if="!isMobileUi()">
+              <li class="desktop">
                 <form class="form-inline" role="form">
                   <div class="checkbox">
                     <label>

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -42,6 +42,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         'savepassword': false,
         'autoconnect': false,
         'nonicklist': utils.isMobileUi(),
+        'alwaysnicklist': false, // only significant on mobile
         'noembed': true,
         'onlyUnread': false,
         'hotlistsync': true,
@@ -173,7 +174,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
             // Check if we should show nicklist or not
             $scope.showNicklist = $scope.updateShowNicklist();
         }
-        if ($scope.swipeStatus <= 0) {
+        if ($scope.swipeStatus <= 0 && !settings.alwaysnicklist) {
             $scope.swipeStatus = $scope.showNicklist ? -1 : 0;
         }
 
@@ -336,10 +337,10 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         // Depending on swipe state
         if ($scope.swipeStatus === 1) {
             /* do nothing */
-        } else if ($scope.swipeStatus === 0 && touch) {
-            $scope.showSidebar();
+        } else if ($scope.swipeStatus === 0) {
+            if (touch) $scope.showSidebar();
         } else if ($scope.swipeStatus === -1) {
-            $scope.closeNick();
+            if (!settings.alwaysnicklist) $scope.closeNick();
         } else {
             console.log("Weird swipe status:", $scope.swipeStatus);
             $scope.swipeStatus = 0; // restore sanity
@@ -351,8 +352,8 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     $rootScope.swipeLeft = function($event) {
         var touch = $event instanceof TouchEvent;
         // Depending on swipe state, ...
-        if ($scope.swipeStatus === 1 && touch) {
-            $scope.hideSidebar();
+        if ($scope.swipeStatus === 1) {
+            if (touch) $scope.hideSidebar();
         } else if ($scope.swipeStatus === 0) {
             $scope.openNick();
         } else if ($scope.swipeStatus === -1) {
@@ -769,7 +770,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     // Watch model and update show setting when it changes
     settings.addCallback('nonicklist', function() {
         $scope.showNicklist = $scope.updateShowNicklist();
-        if ($scope.swipeStatus <= 0) {
+        if ($scope.swipeStatus <= 0 && !settings.alwaysnicklist) {
             $scope.swipeStatus = $scope.showNicklist ? -1 : 0;
         }
         // restore bottom view
@@ -789,7 +790,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
             return false;
         }
         // Check if option no nicklist is set
-        if (settings.nonicklist) {
+        if (settings.nonicklist && !settings.alwaysnicklist) {
             return false;
         }
         // Check if nicklist is empty

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -121,9 +121,6 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         }
     };
 
-    // expose
-    $rootScope.isMobileUi = function() { return utils.isMobileUi(); };
-
     if (typeof $scope.documentVisibilityChange !== "undefined") {
         document.addEventListener($scope.documentVisibilityChange, function() {
             if (!document[$scope.documentHidden]) {

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -30,6 +30,11 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
 
     $scope.command = '';
     $scope.themes = ['dark', 'light', 'black', 'dark-spacious', 'blue', 'base16-default', 'base16-light', 'base16-mocha', 'base16-ocean-dark', 'base16-solarized-dark', 'base16-solarized-light'];
+
+    // Current swipe status. Values:
+    // +1: bufferlist open, nicklist closed
+    //  0: bufferlist closed, nicklist closed
+    // -1: bufferlist closed, nicklist open
     $scope.swipeStatus = 1;
 
     // Initialise all our settings, this needs to include all settings
@@ -170,9 +175,6 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         } else {
             // Check if we should show nicklist or not
             $scope.showNicklist = $scope.updateShowNicklist();
-        }
-        if ($scope.swipeStatus <= 0 && !settings.alwaysnicklist) {
-            $scope.swipeStatus = $scope.showNicklist ? -1 : 0;
         }
 
         if (ab.requestedLines < $scope.lines_per_screen) {
@@ -336,6 +338,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         } else if ($scope.swipeStatus === 0) {
             $scope.showSidebar(); // updates swipe status to 1
         } else if ($scope.swipeStatus === -1) {
+            // hide nicklist
             $scope.swipeStatus = 0;
             $scope.showNicklist = $scope.updateShowNicklist();
         } else {
@@ -351,6 +354,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         if ($scope.swipeStatus === 1) {
             $scope.hideSidebar(); // updates swipe status to 0
         } else if ($scope.swipeStatus === 0) {
+            // show nicklist
             $scope.swipeStatus = -1;
             $scope.showNicklist = $scope.updateShowNicklist();
         } else if ($scope.swipeStatus === -1) {
@@ -746,15 +750,15 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     // Watch model and update show setting when it changes
     settings.addCallback('nonicklist', function() {
         $scope.showNicklist = $scope.updateShowNicklist();
-        if ($scope.swipeStatus <= 0 && !settings.alwaysnicklist) {
-            $scope.swipeStatus = $scope.showNicklist ? -1 : 0;
-        }
         // restore bottom view
         if ($rootScope.connected && $rootScope.bufferBottom) {
             $timeout(function(){
                 $rootScope.updateBufferBottom(true);
             }, 500);
         }
+    });
+    settings.addCallback('alwaysnicklist', function() {
+        $scope.showNicklist = $scope.updateShowNicklist();
     });
     $scope.showNicklist = false;
     // Utility function that template can use to check if nicklist should

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -332,13 +332,12 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         return document.getElementById('content').getAttribute('sidebar-state') === 'visible';
     };
 
-    $scope.swipeRight = function($event) {
-        var touch = $event instanceof TouchEvent;
+    $scope.swipeRight = function() {
         // Depending on swipe state
         if ($scope.swipeStatus === 1) {
             /* do nothing */
         } else if ($scope.swipeStatus === 0) {
-            if (touch) $scope.showSidebar();
+            $scope.showSidebar();
         } else if ($scope.swipeStatus === -1) {
             if (!settings.alwaysnicklist) $scope.closeNick();
         } else {
@@ -349,11 +348,10 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         }
     };
 
-    $rootScope.swipeLeft = function($event) {
-        var touch = $event instanceof TouchEvent;
+    $rootScope.swipeLeft = function() {
         // Depending on swipe state, ...
         if ($scope.swipeStatus === 1) {
-            if (touch) $scope.hideSidebar();
+            $scope.hideSidebar();
         } else if ($scope.swipeStatus === 0) {
             $scope.openNick();
         } else if ($scope.swipeStatus === -1) {


### PR DESCRIPTION
This replaces the "Hide nicklist" setting with an "Always show nicklist setting" (default: false) on mobile. Swiping to the left either closes the bufferlist (if it's open) or opens the nicklist. Swiping to the right either closes the nicklist (if it's open and the above setting is false) or opens the buffer list (if nicklist is closed or the setting is set to true).

This way, it should also work fine in narrow windows on Desktop.

Fixes #838 