### PR TITLE
Implement alt-h

### DIFF
--- a/js/connection.js
+++ b/js/connection.js
@@ -420,6 +420,10 @@ weechat.factory('connection',
         }
     };
 
+    var sendHotlistClearAll = function() {
+        sendMessage("/input hotlist_clear");
+    };
+
     var requestNicklist = function(bufferId, callback) {
         // Prevent requesting nicklist for all buffers if bufferId is invalid
         if (!bufferId) {
@@ -513,6 +517,7 @@ weechat.factory('connection',
         sendMessage: sendMessage,
         sendCoreCommand: sendCoreCommand,
         sendHotlistClear: sendHotlistClear,
+        sendHotlistClearAll: sendHotlistClearAll,
         fetchMoreLines: fetchMoreLines,
         requestNicklist: requestNicklist,
         attemptReconnect: attemptReconnect

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -145,11 +145,9 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     $rootScope.$on('activeBufferChanged', function(event, unreadSum) {
         var ab = models.getActiveBuffer();
 
-        // Discard surplus lines. This is done *before* lines are fetched because that saves us the effort of special handling for the
-        // case where a buffer is opened for the first time ;)
-        var minRetainUnread = ab.lines.length - unreadSum + 5;  // do not discard unread lines and keep 5 additional lines for context
-        var surplusLines = ab.lines.length - (2 * $scope.lines_per_screen + 10);  // retain up to 2*(screenful + 10) + 10 lines because magic numbers
-        var linesToRemove = Math.min(minRetainUnread, surplusLines);
+        // Discard unread lines above 2 screenfuls. We can click through to get more if needs be
+        // This is to keep GB responsive when loading buffers which have seen a lot of traffic. See issue #859
+        var linesToRemove = ab.lines.length - (2 * $scope.lines_per_screen + 10);
 
         if (linesToRemove > 0) {
             ab.lines.splice(0, linesToRemove);  // remove the lines from the buffer

--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -364,6 +364,7 @@ weechat.directive('inputBar', function() {
                         buffer.unread = 0;
                         buffer.notification = 0;
                     });
+                    connection.sendHotlistClearAll();
                 }
 
                 var caretPos;


### PR DESCRIPTION
Fixes #832 
Fixes #835 

This is a slight change on @torhve's work, and sends the message that is bound to [alt-h in weechat](https://weechat.org/files/doc/stable/weechat_user.en.html).

| Key   | Description                                                            | Command                 |
| ------ | -------------------------------------------------------------- | ------------------------- |
| Alt+h | Clear hotlist (activity notification on other buffers) | `/input hotlist_clear` |


