### PR TITLE
Electron on linux: Use a favicon in place of unsupported app badge

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -208,6 +208,22 @@
         mainWindow.loadURL('file://' + __dirname + '/electron-start.html');
         mainWindow.focus();
 
+        /*
+        On linux, update the window icon instead of using the badge feature
+        which only works on osx or the overlay icon which only works on win32.
+        */
+        if (process.platform === 'linux') {
+            var default_favicon = nativeImage.createFromPath(
+                __dirname + '/assets/img/glowing_bear_128x128.png');
+            mainWindow.setIcon(default_favicon);
+            ipcMain.on('favicon', function(event, favicons) {
+
+                var img = nativeImage.createFromDataURL(favicons[0]);
+                mainWindow.setIcon(img);
+                mainWindow.show();
+            });
+        }
+
         // Listen for badge changes
         ipcMain.on('badge', function(event, arg) {
             if (process.platform === "darwin") {

--- a/electron-start.html
+++ b/electron-start.html
@@ -24,6 +24,17 @@ onload = function() {
     webview.addEventListener("new-window", handlenewwindow);
     webview.addEventListener("page-title-set", handletitleset);
 
+    /*
+    On linux, use a tray icon to indicate notification count. This is an
+    inferior but adequate substitute for app icon badges which are not
+    supported by electron on linux.
+    */
+    if (process.platform === 'linux') {
+        webview.addEventListener('page-favicon-updated', function(e) {
+          ipc.send('favicon', e.favicons);
+        });
+    }
+
     ipc.on('browser-window-focus', function() {
         setTimeout(function() { webview.focus(); }, 0);
         setTimeout(function() { webview.executeJavaScript("document.getElementById(\"sendMessage\").focus();") }, 0);

--- a/electron.makefile
+++ b/electron.makefile
@@ -24,4 +24,4 @@ build-electron-darwin: uselocal
 	electron-packager ${ELECTRON_COMMON} --platform=darwin --arch=x64 --version=1.3.3 --icon=assets/img/glowing-bear.icns
 
 build-electron-linux: uselocal
-	electron-packager ${ELECTRON_COMMON} --platform=linux --arch=x64 --version=1.3.3 --icon=assets/img/favicon.ico
+	electron-packager ${ELECTRON_COMMON} --platform=linux --arch=x64 --version=1.3.3 --icon=assets/img/favicon.png


### PR DESCRIPTION
Electron doesn't support app badges on Linux.

This patch adds a tray icon when platform === "linux" to display
the highlight counter, as a poor substitute for the app badges.

Snagged from @20after4's fork :)