### PR TITLE
Fix fontsize unit fixing (assume px if no unit specified)

### DIFF
--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -445,6 +445,11 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     });
     // Update font size when changed
     settings.addCallback('fontsize', function(fontsize) {
+        if (typeof(fontsize) === "number") {
+            // settings module recognizes a fontsize without unit it as a number
+            // and converts, we need to convert back
+            fontsize = fontsize.toString();
+        }
         // If no unit is specified, it should be pixels
         if (fontsize.match(/^[0-9]+$/)) {
             fontsize += 'px';


### PR DESCRIPTION
The settings module sees that we're reading a number, so it converts
the value to a number. Unit detection needs a string, though, so
convert it back into one in that case.