### PR TITLE
Add a button to the input bar to complete nicks

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -89,6 +89,12 @@ input[type=text], input[type=password], #sendMessage {
     margin-bottom: 5px !important;
 }
 
+.btn-complete-nick {
+    position: relative;
+    overflow: hidden;
+    cursor: pointer;
+}
+
 .btn-send-image {
     position: relative;
     overflow: hidden;

--- a/css/themes/base16-default.css
+++ b/css/themes/base16-default.css
@@ -335,11 +335,17 @@ input[type=text]:-moz-placeholder, input[type=password]:-moz-placeholder { /* Fi
     background: var(--base08);
 }
 
-.btn-complete-nick:hover, .btn-complete-nick:focus,
-.btn-send:hover, .btn-send:focus,
-.btn-send-image:hover, .btn-send-image:focus {
+.is-desktop-ui .btn-complete-nick:hover, .btn-complete-nick:focus,
+.is-desktop-ui .btn-send:hover, .btn-send:focus,
+.is-desktop-ui .btn-send-image:hover, .btn-send-image:focus {
     background-color: var(--base07);
     color: var(--base01);
+}
+
+.is-mobile-ui .btn-complete-nick:hover,
+.is-mobile-ui .btn-send:hover,
+.is-mobile-ui .btn-send-image:hover {
+    color: var(--base05);
 }
 
 #connection-infos {

--- a/css/themes/base16-default.css
+++ b/css/themes/base16-default.css
@@ -302,7 +302,7 @@ input[type=text], input[type=password], #sendMessage, .badge {
     box-shadow: 0px 1px 0px rgba(255, 255, 255, 0.1), 0px 1px 7px 0px rgba(0, 0, 0, 0.2) inset;
 }
 
-input[type=text], input[type=password], #sendMessage, .btn-send, .btn-send-image {
+input[type=text], input[type=password], #sendMessage, .btn-send, .btn-send-image, .btn-complete-nick {
     color: var(--base05);
     background: var(--base01);
 }
@@ -335,6 +335,7 @@ input[type=text]:-moz-placeholder, input[type=password]:-moz-placeholder { /* Fi
     background: var(--base08);
 }
 
+.btn-complete-nick:hover, .btn-complete-nick:focus,
 .btn-send:hover, .btn-send:focus,
 .btn-send-image:hover, .btn-send-image:focus {
     background-color: var(--base07);

--- a/css/themes/blue.css
+++ b/css/themes/blue.css
@@ -93,11 +93,17 @@ input[type=text], input[type=password], #sendMessage, .badge, .btn-send, .btn-se
     background: none repeat scroll 0% 0% rgba(0, 0, 0, 0.3);
 }
 
-.btn-complete-nick:hover, .btn-complete-nick:focus,
-.btn-send:hover, .btn-send:focus,
-.btn-send-image:hover, .btn-send-image:focus {
+.is-desktop-ui .btn-complete-nick:hover, .btn-complete-nick:focus,
+.is-desktop-ui .btn-send:hover, .btn-send:focus,
+.is-desktop-ui .btn-send-image:hover, .btn-send-image:focus {
     background-color: #555;
     color: white;
+}
+
+.is-mobile-ui .btn-complete-nick:hover,
+.is-mobile-ui .btn-send:hover,
+.is-mobile-ui .btn-send-image:hover {
+    color: #ccc;
 }
 
 .nav-pills li:nth-child(2n) {

--- a/css/themes/blue.css
+++ b/css/themes/blue.css
@@ -88,11 +88,12 @@ input[type=text], input[type=password], #sendMessage, .badge {
    border: 1px solid #4a5b6c;
 }
 
-input[type=text], input[type=password], #sendMessage, .badge, .btn-send, .btn-send-image {
+input[type=text], input[type=password], #sendMessage, .badge, .btn-send, .btn-send-image, .btn-complete-nick {
     color: #ccc;
     background: none repeat scroll 0% 0% rgba(0, 0, 0, 0.3);
 }
 
+.btn-complete-nick:hover, .btn-complete-nick:focus,
 .btn-send:hover, .btn-send:focus,
 .btn-send-image:hover, .btn-send-image:focus {
     background-color: #555;

--- a/css/themes/dark.css
+++ b/css/themes/dark.css
@@ -87,11 +87,17 @@ input[type=text], input[type=password], #sendMessage, .badge, .btn-send, .btn-se
     background: none repeat scroll 0% 0% rgba(0, 0, 0, 0.3);
 }
 
-.btn-complete-nick:hover, .btn-complete-nick:focus,
-.btn-send:hover, .btn-send:focus,
-.btn-send-image:hover, .btn-send-image:focus {
+.is-desktop-ui .btn-complete-nick:hover, .btn-complete-nick:focus,
+.is-desktop-ui .btn-send:hover, .btn-send:focus,
+.is-desktop-ui .btn-send-image:hover, .btn-send-image:focus {
     background-color: #555;
     color: white;
+}
+
+.is-mobile-ui .btn-complete-nick:hover,
+.is-mobile-ui .btn-send:hover,
+.is-mobile-ui .btn-send-image:hover {
+    color: #ccc;
 }
 
 #connection-infos {

--- a/css/themes/dark.css
+++ b/css/themes/dark.css
@@ -82,11 +82,12 @@ input[type=text], input[type=password], #sendMessage, .badge {
     box-shadow: 0px 1px 0px rgba(255, 255, 255, 0.1), 0px 1px 7px 0px rgba(0, 0, 0, 0.8) inset;
 }
 
-input[type=text], input[type=password], #sendMessage, .badge, .btn-send, .btn-send-image {
+input[type=text], input[type=password], #sendMessage, .badge, .btn-send, .btn-send-image, .btn-complete-nick {
     color: #ccc;
     background: none repeat scroll 0% 0% rgba(0, 0, 0, 0.3);
 }
 
+.btn-complete-nick:hover, .btn-complete-nick:focus,
 .btn-send:hover, .btn-send:focus,
 .btn-send-image:hover, .btn-send-image:focus {
     background-color: #555;

--- a/css/themes/light.css
+++ b/css/themes/light.css
@@ -27,6 +27,7 @@ html {
     background: #428BCA;
 }
 
+.btn-complete-nick,
 .btn-send,
 .btn-send-image, {
     background: none repeat scroll 0% 0% rgba(255, 255, 255, 0.3);

--- a/css/themes/light.css
+++ b/css/themes/light.css
@@ -34,6 +34,12 @@ html {
     color: #428BCA;
 }
 
+.is-mobile-ui .btn-complete-nick:hover,
+.is-mobile-ui .btn-send:hover,
+.is-mobile-ui .btn-send-image:hover {
+    color: #428BCA;
+}
+
 tr.bufferline:hover {
     background-color: #efefef;
 }

--- a/directives/input.html
+++ b/directives/input.html
@@ -1,4 +1,4 @@
-<form class="form form-horizontal {{ utils.isMobileUi() ? 'is-mobile-ui' : 'is-desktop-ui' }}" id="inputform" ng-submit="sendMessage()" imgur-drop>
+<form class="form form-horizontal" ng-class="utils.isMobileUi() ? 'is-mobile-ui' : 'is-desktop-ui'" id="inputform" ng-submit="sendMessage()" imgur-drop>
   <div class="input-group">
     <textarea id="{{inputId}}" class="form-control favorite-font" ng-trim="false" rows="1" ng-change="inputChanged()" autocomplete="on" ng-model="command" ng-focus="hideSidebar()">
     </textarea>

--- a/directives/input.html
+++ b/directives/input.html
@@ -3,7 +3,7 @@
     <textarea id="{{inputId}}" class="form-control favorite-font" ng-trim="false" rows="1" ng-change="inputChanged()" autocomplete="on" ng-model="command" ng-focus="hideSidebar()">
     </textarea>
     <span class="input-group-btn">
-      <button class="btn btn-complete-nick unselectable" title="Complete nick" ng-hide="!utils.isMobileUi()" ng-click="handleCompleteNickButton($event)"><i class="glyphicon glyphicon-chevron-right"></i></button>
+      <button class="btn btn-complete-nick unselectable" title="Complete nick" ng-hide="!utils.isMobileUi()" ng-click="handleCompleteNickButton($event)"><i class="glyphicon glyphicon-bullhorn"></i></button>
       <label class="btn btn-send-image unselectable" for="imgur-upload" title="Send image">
         <i class="glyphicon glyphicon-picture"></i>
         <input type="file" accept="image/*" multiple title="Send image" id="imgur-upload" class="imgur-upload" file-change="uploadImage($event, files)">

--- a/directives/input.html
+++ b/directives/input.html
@@ -3,7 +3,7 @@
     <textarea id="{{inputId}}" class="form-control favorite-font" ng-trim="false" rows="1" ng-change="inputChanged()" autocomplete="on" ng-model="command" ng-focus="hideSidebar()">
     </textarea>
     <span class="input-group-btn">
-      <button class="btn btn-complete-nick unselectable" title="Complete nick" ng-hide="hideCompleteNickButton()" ng-click="handleCompleteNickButton($event)"><i class="glyphicon glyphicon-chevron-right"></i></button>
+      <button class="btn btn-complete-nick unselectable" title="Complete nick" ng-hide="!utils.isMobileUi()" ng-click="handleCompleteNickButton($event)"><i class="glyphicon glyphicon-chevron-right"></i></button>
       <label class="btn btn-send-image unselectable" for="imgur-upload" title="Send image">
         <i class="glyphicon glyphicon-picture"></i>
         <input type="file" accept="image/*" multiple title="Send image" id="imgur-upload" class="imgur-upload" file-change="uploadImage($event, files)">

--- a/directives/input.html
+++ b/directives/input.html
@@ -1,4 +1,4 @@
-<form class="form form-horizontal" id="inputform" ng-submit="sendMessage()" imgur-drop>
+<form class="form form-horizontal {{ utils.isMobileUi() ? 'is-mobile-ui' : 'is-desktop-ui' }}" id="inputform" ng-submit="sendMessage()" imgur-drop>
   <div class="input-group">
     <textarea id="{{inputId}}" class="form-control favorite-font" ng-trim="false" rows="1" ng-change="inputChanged()" autocomplete="on" ng-model="command" ng-focus="hideSidebar()">
     </textarea>

--- a/directives/input.html
+++ b/directives/input.html
@@ -3,7 +3,7 @@
     <textarea id="{{inputId}}" class="form-control favorite-font" ng-trim="false" rows="1" ng-change="inputChanged()" autocomplete="on" ng-model="command" ng-focus="hideSidebar()">
     </textarea>
     <span class="input-group-btn">
-      <button class="btn btn-complete-nick unselectable" title="Complete nick" ng-click="handleCompleteNickButton($event)"><i class="glyphicon glyphicon-chevron-right"></i></button>
+      <button class="btn btn-complete-nick unselectable" title="Complete nick" ng-hide="hideCompleteNickButton()" ng-click="handleCompleteNickButton($event)"><i class="glyphicon glyphicon-chevron-right"></i></button>
       <label class="btn btn-send-image unselectable" for="imgur-upload" title="Send image">
         <i class="glyphicon glyphicon-picture"></i>
         <input type="file" accept="image/*" multiple title="Send image" id="imgur-upload" class="imgur-upload" file-change="uploadImage($event, files)">

--- a/directives/input.html
+++ b/directives/input.html
@@ -3,6 +3,7 @@
     <textarea id="{{inputId}}" class="form-control favorite-font" ng-trim="false" rows="1" ng-change="inputChanged()" autocomplete="on" ng-model="command" ng-focus="hideSidebar()">
     </textarea>
     <span class="input-group-btn">
+      <button class="btn btn-complete-nick unselectable" title="Complete nick" ng-click="handleCompleteNickButton($event)"><i class="glyphicon glyphicon-chevron-right"></i></button>
       <label class="btn btn-send-image unselectable" for="imgur-upload" title="Send image">
         <i class="glyphicon glyphicon-picture"></i>
         <input type="file" accept="image/*" multiple title="Send image" id="imgur-upload" class="imgur-upload" file-change="uploadImage($event, files)">

--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -25,6 +25,9 @@ weechat.directive('inputBar', function() {
                              settings,
                              utils) {
 
+            // Expose utils to be able to check if we're on a mobile UI
+            $scope.utils = utils;
+
             // E.g. Turn :smile: into the unicode equivalent
             $scope.inputChanged = function() {
                 $scope.command = emojione.shortnameToUnicode($scope.command);
@@ -503,10 +506,6 @@ weechat.directive('inputBar', function() {
                 $event.preventDefault();
                 $scope.completeNick();
                 return true;
-            };
-
-            $scope.hideCompleteNickButton = function() {
-                return !utils.isMobileUi();
             };
         }]
     };

--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -497,6 +497,12 @@ weechat.directive('inputBar', function() {
                     return true;
                 }
             };
+
+            $scope.handleCompleteNickButton = function($event) {
+                $event.preventDefault();
+                $scope.completeNick();
+                return true;
+            };
         }]
     };
 });

--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -14,7 +14,7 @@ weechat.directive('inputBar', function() {
             command: '=command'
         },
 
-        controller: ['$rootScope', '$scope', '$element', '$log', 'connection', 'imgur', 'models', 'IrcUtils', 'settings', function($rootScope,
+        controller: ['$rootScope', '$scope', '$element', '$log', 'connection', 'imgur', 'models', 'IrcUtils', 'settings', 'utils', function($rootScope,
                              $scope,
                              $element, //XXX do we need this? don't seem to be using it
                              $log,
@@ -22,7 +22,8 @@ weechat.directive('inputBar', function() {
                              imgur,
                              models,
                              IrcUtils,
-                             settings) {
+                             settings,
+                             utils) {
 
             // E.g. Turn :smile: into the unicode equivalent
             $scope.inputChanged = function() {
@@ -502,6 +503,10 @@ weechat.directive('inputBar', function() {
                 $event.preventDefault();
                 $scope.completeNick();
                 return true;
+            };
+
+            $scope.hideCompleteNickButton = function() {
+                return !utils.isMobileUi();
             };
         }]
     };

--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -505,6 +505,11 @@ weechat.directive('inputBar', function() {
             $scope.handleCompleteNickButton = function($event) {
                 $event.preventDefault();
                 $scope.completeNick();
+
+                setTimeout(function() {
+                    $scope.getInputNode().focus();
+                }, 0);
+
                 return true;
             };
         }]


### PR DESCRIPTION
Add a button to allow nick completion on mobile, rather than relying on the user using a software keyboard that has a TAB key.

The glyph being used in the button is `glyphicon-chevron-right`, only because that's the only thing in Glyphicons that resembles what most users would perceive as a TAB key.