### PR TITLE
Changed "close Window" shortcut from Ctrl+W to Ctrl+Q.

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -101,7 +101,7 @@
         },
         {
             label: 'Close',
-            accelerator: 'CmdOrCtrl+W',
+            accelerator: 'CmdOrCtrl+Q',
             role: 'close'
         },
         ]


### PR DESCRIPTION
Ctrl+W should be for closing **tabs**, imo. Ctrl+Q would seem to be the standard key for closing a **window**.