### PR TITLE
Allow disabling the emoji conversion in the input bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -474,6 +474,16 @@ npm run build-electron-{windows, darwin, linux}</pre>
                   </div>
                 </form>
               </li>
+              <li>
+                <form class="form-inline" role="form">
+                  <div class="checkbox">
+                    <label>
+                      <input type="checkbox" ng-model="settings.enableEmojiConversion">
+                      Enable converting emoji short-names into Unicode emoji <span class="text-muted settings-help">Allows you to type :smile: and have it convert to the smile emoji.</span>
+                    </label>
+                  </div>
+                </form>
+              </li>
                <li>
                 <form class="form-inline" role="form">
                   <div class="checkbox">

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -45,6 +45,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         'enableJSEmoji': (utils.isMobileUi() ? false : true),
         'enableMathjax': false,
         'enableQuickKeys': true,
+        'enableEmojiConversion': true,
         'customCSS': '',
         "currentlyViewedBuffers":{},
     });

--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -30,7 +30,9 @@ weechat.directive('inputBar', function() {
 
             // E.g. Turn :smile: into the unicode equivalent
             $scope.inputChanged = function() {
-                $scope.command = emojione.shortnameToUnicode($scope.command);
+                if (settings.enableEmojiConversion) {
+                    $scope.command = emojione.shortnameToUnicode($scope.command);
+                }
             };
 
             /*


### PR DESCRIPTION
Simple patch to allow disabling the EmojiOne conversion that happens on inputChanged in the input bar.