### PR TITLE
Make videoPlugin work for all imgur gifv videos

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -339,17 +339,27 @@ plugins.factory('userPlugins', function() {
      */
     var videoPlugin = new UrlPlugin('video', function(url) {
         if (url.match(/\.(3gp|avi|flv|gifv|mkv|mp4|ogv|webm|wmv)\b/i)) {
-            if (url.match(/^http:\/\/(i\.)?imgur\.com\//i)) {
-                // remove protocol specification to load over https if used by g-b
-                url = url.replace(/\.(gifv)\b/i, ".webm");
-            }
             return function() {
-                var element = this.getElement();
+                var element = this.getElement(), src;
                 var velement = angular.element('<video autoplay loop muted></video>')
                                      .addClass('embed')
-                                     .attr('width', '560')
-                                     .append(angular.element('<source></source>')
-                                                    .attr('src', url));
+                                     .attr('width', '560');
+                // imgur doesn't always have webm for gifv so add sources for webm and mp4
+                if (url.match(/^http:\/\/(i\.)?imgur\.com\//i) &&
+                    url.indexOf('.gifv') > -1) {
+                    src = angular.element('<source></source>')
+                                 .attr('src', url.replace(/\.gifv\b/i, ".webm"))
+                                 .attr('type', 'video/webm');
+                    velement.append(src);
+                    src = angular.element('<source></source>')
+                                 .attr('src', url.replace(/\.gifv\b/i, ".mp4"))
+                                 .attr('type', 'video/mp4');
+                    velement.append(src);
+                } else {
+                    src = angular.element('<source></source>')
+                                 .attr('src', url);
+                    velement.append(src);
+                }
                 element.innerHTML = velement.prop('outerHTML');
             };
         }

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -281,8 +281,8 @@ plugins.factory('userPlugins', function() {
             if (url.indexOf("^https?://fukung.net/v/") != -1) {
                 url = url.replace(/.*\//, "http://media.fukung.net/imgs/");
             } else if (url.match(/^http:\/\/(i\.)?imgur\.com\//i)) {
-                // remove protocol specification to load over https if used by g-b
-                url = url.replace(/http:/, "https:");
+                // imgur: always use https. avoids mixed content warnings
+                url = url.replace(/^http:/, "https:");
             } else if (url.match(/^https:\/\/www\.dropbox\.com\/s\/[a-z0-9]+\//i)) {
                 // Dropbox requires a get parameter, dl=1
                 var dbox_url = document.createElement("a");
@@ -340,7 +340,7 @@ plugins.factory('userPlugins', function() {
     var videoPlugin = new UrlPlugin('video', function(url) {
         if (url.match(/\.(3gp|avi|flv|gifv|mkv|mp4|ogv|webm|wmv)\b/i)) {
             if (url.match(/^http:\/\/(i\.)?imgur\.com\//i)) {
-                // imgur: force https
+                // imgur: always use https. avoids mixed content warnings
                 url = url.replace(/^http:/, "https:");
             }
             return function() {

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -339,14 +339,17 @@ plugins.factory('userPlugins', function() {
      */
     var videoPlugin = new UrlPlugin('video', function(url) {
         if (url.match(/\.(3gp|avi|flv|gifv|mkv|mp4|ogv|webm|wmv)\b/i)) {
+            if (url.match(/^http:\/\/(i\.)?imgur\.com\//i)) {
+                // imgur: force https
+                url = url.replace(/^http:/, "https:");
+            }
             return function() {
                 var element = this.getElement(), src;
                 var velement = angular.element('<video autoplay loop muted></video>')
                                      .addClass('embed')
                                      .attr('width', '560');
                 // imgur doesn't always have webm for gifv so add sources for webm and mp4
-                if (url.match(/^http:\/\/(i\.)?imgur\.com\//i) &&
-                    url.indexOf('.gifv') > -1) {
+                if (url.match(/^https:\/\/(i\.)?imgur\.com\/.*\.gifv/i)) {
                     src = angular.element('<source></source>')
                                  .attr('src', url.replace(/\.gifv\b/i, ".webm"))
                                  .attr('type', 'video/webm');


### PR DESCRIPTION
Some gifv links on imgur.com do not have an associated webm video
and only provide an mp4 video. Add two source elements with proper
mimetypes for both types of video. The video player will fall back
to the secondary source if the first cannot be loaded (due to 404)

Example: Trying to load the webm version of this video

  http://i.imgur.com/i7D4GRb.webm

will result in a 302 redirect to the gifv url, which tries to load
an HTML document. This will cause our video player to reject the
document as an invalid video format (text/html); on some videos it
will simply 404. The mp4 version is available and our player will
fall back to that.