### PR TITLE
Fix Ctrl+W when the cursor follows a space.

### DIFF
--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -467,7 +467,7 @@ weechat.directive('inputBar', function() {
                     // Ctrl-w
                     } else if (code == 87) {
                         var trimmedValue = $scope.command.slice(0, caretPos);
-                        var lastSpace = trimmedValue.replace(/ +$/, '').lastIndexOf(' ') + 1;
+                        var lastSpace = trimmedValue.replace(/\s+$/, '').lastIndexOf(' ') + 1;
                         $scope.command = $scope.command.slice(0, lastSpace) + $scope.command.slice(caretPos, $scope.command.length);
                         setTimeout(function() {
                             inputNode.setSelectionRange(lastSpace, lastSpace);

--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -467,7 +467,7 @@ weechat.directive('inputBar', function() {
                     // Ctrl-w
                     } else if (code == 87) {
                         var trimmedValue = $scope.command.slice(0, caretPos);
-                        var lastSpace = trimmedValue.lastIndexOf(' ') + 1;
+                        var lastSpace = trimmedValue.replace(/ +$/, '').lastIndexOf(' ') + 1;
                         $scope.command = $scope.command.slice(0, lastSpace) + $scope.command.slice(caretPos, $scope.command.length);
                         setTimeout(function() {
                             inputNode.setSelectionRange(lastSpace, lastSpace);


### PR DESCRIPTION
This key binding does "Delete from cursor to previous space". When the text before the cursor was `some example`, it would find the space after "some" and delete "example". When hitting Ctrl+W *again*, it would find the same space again… and delete nothing.

This changes the code to ignore trailing spaces before the cursor for the purpose of finding the previous space, so that something (if at all possible) is always deleted.