### PR TITLE
Make buffer search case insensitive

### DIFF
--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -711,7 +711,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
             }
         } else {
             // filter by buffer name
-            return buffer.fullName.indexOf($scope.search) !== -1;
+            return buffer.fullName.toLowerCase().indexOf($scope.search.toLowerCase()) !== -1;
         }
     };
 


### PR DESCRIPTION
Currently, the buffer search textbox is case sensitive. This is an issue on mobile, where some keyboards automatically capitalize the first letter of a word.

This PR .toLowerCase()s both the buffer name and the search terms, and makes the buffer search case insensitive.