### PR TITLE
Revert "[DISCUSS] Remove "scroll to readmarker" functionality"

### DIFF
--- a/js/connection.js
+++ b/js/connection.js
@@ -505,8 +505,10 @@ weechat.factory('connection',
             }
             $rootScope.loadingLines = false;
 
-            // "Scroll" to maintain position
-            $rootScope.scrollWithBuffer(/* moreLines */ true);
+            // Only scroll to read marker if we didn't have all unread lines previously, but have them now
+            var scrollToReadmarker = !hadAllUnreadLines && buffer.lastSeen >= 0;
+            // Scroll to correct position
+            $rootScope.scrollWithBuffer(scrollToReadmarker, true);
         });
     };
 


### PR DESCRIPTION
Reverts glowing-bear/glowing-bear#905

This broke too much stuff, #950 tries to fix some of it but it's such a minefield.

I think the entire scrolling logic needs a fresh start. Currently, rendering of the table (if it has multiline lines) causes a resize event and causes chaos. #905 seems to have unearthed some nasty scrolling issues.