### PR TITLE
Upgrade karma-phantomjs-launcher to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "karma": "~0.13",
     "karma-jasmine": "^0.3.6",
     "karma-junit-reporter": "^0.2.2",
-    "karma-phantomjs-launcher": "^0.2.1",
+    "karma-phantomjs-launcher": "^1.0.0",
     "phantomjs-prebuilt": "^2.1.1",
     "protractor": "~0.20.1",
     "shelljs": "^0.2.6",


### PR DESCRIPTION
`phantomjs` was renamed to `phatomjs-prebuilt` but this change was integrated in the 1.0.0 release of `karma-phantomjs-launcher`. The previous versions import the `phantomjs` module, which results in a failure since this module is not anymore installed. Consequently, the `run_tests.sh` script hands infinitely because the launcher fails.

This commit makes the run_tests.sh script work again. :-)