### PR TITLE
Add a link to a PKGBUILD for Archlinux users

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can run Glowing Bear in many ways:
  * Chrome app ("Tools", then "Create application shortcuts")
  * Android Chrome app, a full-screen experience ("Add to homescreen").
  * [Android app](https://play.google.com/store/apps/details?id=com.glowing_bear) that you can install from the Google Play Store
- * Electron app, for Windows, Linux and MacOSX. ```npm install; npm install electron-packager; npm run build-electron-{windows, darwin, linux}```
+ * Electron app, for Windows, Linux and MacOSX. ```npm install; npm install electron-packager; npm run build-electron-{windows, darwin, linux}```. If you're using Archlinux, a [PKGBUILD](https://aur.archlinux.org/packages/glowing-bear-git/) is available.
 
 <a href="https://play.google.com/store/apps/details?id=com.glowing_bear"><img alt="Android app on Google Play" src="/assets/img/badge_playstore.png" /></a>
 


### PR DESCRIPTION
It's always cool to have a `PKGBUILD` for every app you use on Arch Linux. I created one for glowing-bear, you might want to add a link to it to the project's README to make the setup easier. 😉 