### PR TITLE
extend emojify filter to convert shortnames as well

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -180,8 +180,10 @@ weechat.filter('emojify', function() {
             // Emoji live in the D800-DFFF surrogate plane; only bother passing
             // this range to CPU-expensive unicodeToImage();
             var emojiRegex = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g;
-            if (emojiRegex.test(text)) {
-                return emojione.unicodeToImage(text);
+            // regex to look for typical shortname syntax in tools like Slack
+            var shortnameRegex = /\:[\+-_a-zA-Z0-9]+\:/g;
+            if (emojiRegex.test(text) || shortnameRegex.test(text)) {
+                return emojione.toImage(text);
             } else {
                 return(text);
             }

--- a/js/filters.js
+++ b/js/filters.js
@@ -181,7 +181,7 @@ weechat.filter('emojify', function() {
             // this range to CPU-expensive unicodeToImage();
             var emojiRegex = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g;
             // regex to look for typical shortname syntax in tools like Slack
-            var shortnameRegex = /\:[\+-_a-zA-Z0-9]+\:/g;
+            var shortnameRegex = /\:[\+\-_a-zA-Z0-9]+\:/g;
             if (emojiRegex.test(text) || shortnameRegex.test(text)) {
                 return emojione.toImage(text);
             } else {


### PR DESCRIPTION
This change will convert shortnames like `:see_no_evil:` (🙈) to emojis / images as well. Emojione will convert only known shortnames to its equivalent. Thus custom Slack emojis will be displayed as text.