### PR TITLE
Fix bufferlist item height on condensed layout

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -851,6 +851,11 @@ img.emojione {
         font-size: 14px;
     }
 
+    .nav-pills li.buffer {
+        min-height: 30px;
+        max-height: 30px;
+    }
+
     .nav-pills li a {
         padding: 10px 15px;
     }


### PR DESCRIPTION
Fixes #1012, based on @rain-1's suggestion

This slightly increases the height for the other buffers, but that's required to prevent jumping.