### PR TITLE
Keep track of unread counts for servers' buffers for 'show only unread' view

### DIFF
--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -134,6 +134,8 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
                 var buffer = models.getActiveBuffer();
                 // This can also be triggered before connecting to the relay, check for null (not undefined!)
                 if (buffer !== null) {
+                    var server = models.getServerForBuffer(buffer);
+                    server.unread -= (buffer.unread + buffer.notification);
                     buffer.unread = 0;
                     buffer.notification = 0;
 
@@ -716,9 +718,13 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
                 return true;
             }
             // Always show core buffer in the list (issue #438)
-            // Also show server buffers in hierarchical view
-            if (buffer.fullName === "core.weechat" || (settings.orderbyserver && buffer.type === 'server')) {
+            if (buffer.fullName === "core.weechat") {
                 return true;
+            }
+
+            // In hierarchical view, show server iff it has a buffer with unread messages
+            if (settings.orderbyserver && buffer.type === 'server') {
+                return models.getServerForBuffer(buffer).unread > 0;
             }
 
             // Always show pinned buffers

--- a/js/handlers.js
+++ b/js/handlers.js
@@ -161,13 +161,16 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
             }
 
             if (!manually && (!buffer.active || !$rootScope.isWindowFocused())) {
+                var server = models.getServerForBuffer(buffer);
                 if (buffer.notify > 1 && _.contains(message.tags, 'notify_message') && !_.contains(message.tags, 'notify_none')) {
                     buffer.unread++;
+                    server.unread++;
                     $rootScope.$emit('notificationChanged');
                 }
 
                 if ((buffer.notify !== 0 && message.highlight) || _.contains(message.tags, 'notify_private')) {
                     buffer.notification++;
+                    server.unread++;
                     notifications.createHighlight(buffer, message);
                     $rootScope.$emit('notificationChanged');
                 }
@@ -186,6 +189,12 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
                 handleBufferUpdate(buffer, bufferInfos[i]);
             } else {
                 buffer = new models.Buffer(bufferInfos[i]);
+                if (buffer.type === 'server') {
+                    models.registerServer(buffer);
+                } else {
+                    var server = models.getServerForBuffer(buffer);
+                    server.unread += buffer.unread + buffer.notification;
+                }
                 models.addBuffer(buffer);
                 // Switch to first buffer on startup
                 var shouldResume = bufferResume.shouldResume(buffer);
@@ -214,7 +223,9 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
         buffer.number = message.number;
         buffer.hidden = message.hidden;
 
-        // reset these, hotlist info will arrive shortly
+        // reset unread counts, hotlist info will arrive shortly
+        var server = models.getServerForBuffer(buffer);
+        server.unread -= (buffer.unread + buffer.notification);
         buffer.notification = 0;
         buffer.unread = 0;
         buffer.lastSeen = -1;
@@ -238,6 +249,12 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
     var handleBufferOpened = function(message) {
         var bufferMessage = message.objects[0].content[0];
         var buffer = new models.Buffer(bufferMessage);
+        if (buffer.type === 'server') {
+            models.registerServer(buffer);
+        } else {
+            var server = models.getServerForBuffer(buffer);
+            server.unread += buffer.unread + buffer.notification;
+        }
         models.addBuffer(buffer);
     };
 
@@ -353,6 +370,9 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
             buffer.unread = 0;
             buffer.notification = 0;
         });
+        _.each(models.getServers(), function(server) {
+            server.unread = 0;
+        });
         if (message.objects.length > 0) {
             var hotlist = message.objects[0].content;
             hotlist.forEach(function(l) {
@@ -376,6 +396,9 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
                 */
                 var unreadSum = _.reduce(l.count, function(memo, num) { return memo + num; }, 0);
                 buffer.lastSeen = buffer.lines.length - 1 - unreadSum;
+
+                // update server buffer. Don't incude index 0 -> not unreadSum
+                models.getServerForBuffer(buffer).unread += l.count[1] + l.count[2] + l.count[3];
             });
         }
         // the unread badges in the bufferlist doesn't update if we don't do this

--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -438,6 +438,10 @@ weechat.directive('inputBar', function() {
                         buffer.unread = 0;
                         buffer.notification = 0;
                     });
+                    var servers = models.getServers();
+                    _.each(servers, function(server) {
+                        server.unread = 0;
+                    });
                     connection.sendHotlistClearAll();
                 }
 

--- a/js/models.js
+++ b/js/models.js
@@ -473,11 +473,26 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
         };
     };
 
+    this.Server = function() {
+        var id = 0; // will be set later on
+        var unread = 0;
+
+        return {
+            id: id,
+            unread: unread
+        };
+    };
+
 
     var activeBuffer = null;
     var previousBuffer = null;
 
-    this.model = { 'buffers': {} };
+    this.model = { 'buffers': {}, 'servers': {} };
+
+    this.registerServer = function(buffer) {
+        var key = buffer.plugin + '.' + buffer.server;
+        this.getServer(key).id = buffer.id;
+    };
 
     /*
      * Adds a buffer to the list
@@ -563,6 +578,8 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
 
         var unreadSum = activeBuffer.unread + activeBuffer.notification;
 
+        this.getServerForBuffer(activeBuffer).unread -= unreadSum;
+
         activeBuffer.active = true;
         activeBuffer.unread = 0;
         activeBuffer.notification = 0;
@@ -585,6 +602,7 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
      */
     this.reinitialize = function() {
         this.model.buffers = {};
+        this.model.servers = {};
     };
 
     /*
@@ -595,6 +613,35 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
      */
     this.getBuffer = function(bufferId) {
         return this.model.buffers[bufferId];
+    };
+
+    /*
+     * Returns the server list
+     */
+    this.getServers = function() {
+        return this.model.servers;
+    };
+
+    /*
+     * Returns the server object for a specific key, creating it if it does not exist
+     * @param key the server key
+     * @return the server object
+     */
+    this.getServer = function(key) {
+        if (this.model.servers[key] === undefined) {
+            this.model.servers[key] = this.Server();
+        }
+        return this.model.servers[key];
+    };
+
+    /*
+     * Returns info on the server buffer for a specific buffer
+     * @param buffer the buffer
+     * @return the server object
+     */
+    this.getServerForBuffer = function(buffer) {
+        var key = buffer.plugin + '.' + buffer.server;
+        return this.getServer(key);
     };
 
     /*


### PR DESCRIPTION
Maintain unread info for all buffers belonging to a server.  This info
is used to hide server buffers for which *no* associated buffer has
activity when 'Only show buffers with unread messages' is enabled.

Closes #1019