### PR TITLE
Add a Dockerfile and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.*
+*.sh
+*.md
+test
+electron-*
+COPYING
+package.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:mainline-alpine
+COPY . /usr/share/nginx/html


### PR DESCRIPTION
This adds a simple `Dockerfile` to run glowing-bear on Docker.  
I was unsure if more files can be added to the `.dockerignore`.