### PR TITLE
[WIP] Respect safe area constraints on webkit

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -223,7 +223,9 @@ input[type=text], input[type=password], #sendMessage {
     overflow-y: auto;
     overflow-x: hidden;
     padding-top: 35px; /* topbar */
+    padding-right: env(safe-area-inset-right);
     padding-bottom: 1px; /* need to force a padding here */
+    padding-left: env(safe-area-inset-left);
     font-size: smaller;
     transition:0.2s ease-in-out;
     z-index: 2;
@@ -333,6 +335,7 @@ input[type=text], input[type=password], #sendMessage {
 .content {
     height: 100%;
     min-height: 100%;
+    padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
 }
 
 #bufferlines {
@@ -388,6 +391,7 @@ td.time {
     bottom: 0;
     height: 35px;
     width: 100%;
+    margin-bottom: env(safe-area-inset-bottom); /* margin for home-indicator on iPhone X */
     -webkit-transition:0.2s ease-in-out all;
     transition:0.2s ease-in-out all;
     z-index: 1;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">


### PR DESCRIPTION
This adds limited support to respect constraints on newer iPhones, especially when used as PWA.

More information about this can be found on [the official webkit blog](https://webkit.org/blog/7929/designing-websites-for-iphone-x/).

There's one more issue I am facing which is the bottom margin on `.footer`. Once you open the software keyboard, the bottom margin stays, leaving a gap between input and keyboard. This has eventually be solved using javascript and checking for the keyboard being open.