### PR TITLE
Fix color issue in chan topic.

### DIFF
--- a/index.html
+++ b/index.html
@@ -541,7 +541,7 @@ npm run build-electron-{windows, darwin, linux}</pre>
           <div class="modal-header">
             <button type="button" class="close" ng-click="closeModal($event)" aria-hidden="true">&times;</button>
             <h4 class="modal-title">Channel topic {{ activeBuffer().shortName || activeBuffer().fullName }}</h4>
-            <p ng-repeat="part in activeBuffer().title" ng-class="::part.classes" ng-bind-html="::(part.text | linky:'_blank':{rel:'noopener noreferrer'} | DOMfilter:'irclinky')"></p>
+            <span ng-repeat="part in activeBuffer().title" ng-class="::part.classes" ng-bind-html="::(part.text | linky:'_blank':{rel:'noopener noreferrer'} | DOMfilter:'irclinky')"></span>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-primary" ng-click="closeModal($event)">Close</button>


### PR DESCRIPTION
When the chan topic have some color definied, the full topic view print each color on multiple lines.

![image](https://user-images.githubusercontent.com/2803296/47673802-ef96c880-dbb5-11e8-87b2-025ef7190c0a.png)

Now : 

![image](https://user-images.githubusercontent.com/2803296/47673866-1c4ae000-dbb6-11e8-8236-016c9a257f1e.png)
