### PR TITLE
Disable periodic hotlist sync if read status sync is disabled

### DIFF
--- a/js/connection.js
+++ b/js/connection.js
@@ -4,10 +4,11 @@
 var weechat = angular.module('weechat');
 
 weechat.factory('connection',
-                ['$rootScope', '$log', 'handlers', 'models', 'ngWebsockets', function($rootScope,
+                ['$rootScope', '$log', 'handlers', 'models', 'settings', 'ngWebsockets', function($rootScope,
          $log,
          handlers,
          models,
+         settings,
          ngWebsockets) {
 
     var protocol = new weeChat.Protocol();
@@ -194,17 +195,19 @@ weechat.factory('connection',
                         handlers.handleHotlistInfo(hotlist);
 
                     });
-                    // Schedule hotlist syncing every so often so that this
-                    // client will have unread counts (mostly) in sync with
-                    // other clients or terminal usage directly.
-                    setInterval(function() {
-                        if ($rootScope.connected) {
-                            _requestHotlist().then(function(hotlist) {
-                                handlers.handleHotlistInfo(hotlist);
+                    if (settings.hotlistsync) {
+                        // Schedule hotlist syncing every so often so that this
+                        // client will have unread counts (mostly) in sync with
+                        // other clients or terminal usage directly.
+                        setInterval(function() {
+                            if ($rootScope.connected) {
+                                _requestHotlist().then(function(hotlist) {
+                                    handlers.handleHotlistInfo(hotlist);
 
-                            });
-                        }
-                    }, 60000); // Sync hotlist every 60 second
+                                });
+                            }
+                        }, 60000); // Sync hotlist every 60 second
+                    }
 
 
                     // Fetch weechat time format for displaying timestamps


### PR DESCRIPTION
This will cause weechat and Glowing Bear read status to drift apart but
that's how it used to be before we added the periodic sync anyway, and
properly fixing it would require maintaining *tons* of state, so that's life.

Fixes #1035 some more