### PR TITLE
Don't linkify hostnames in join/part messages.

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,7 +337,6 @@ npm run build-electron-{windows, darwin, linux}</pre>
            --><td class="message"><!--
              --><div ng-repeat="metadata in ::bufferline.metadata" plugin data="::metadata"></div><!--
              --><span ng-repeat="part in ::bufferline.content" class="text" ng-class="::part.classes.concat(['line-' + part.$$hashKey.replace(':','_')])" ng-bind-html="::part.text | conditionalLinkify:part.classes.includes('cof-chat_host') | DOMfilter:'irclinky' | DOMfilter:'emojify':settings.enableJSEmoji | DOMfilter:'inlinecolour' | DOMfilter:'latexmath':('.line-' + part.$$hashKey.replace(':','_')):settings.enableMathjax"></span>
-             <!-- <pre>{{bufferline | json}}</pre> -->
               </td>
             </tr>
             <tr class="readmarker" ng-if="activeBuffer().lastSeen==$index">

--- a/index.html
+++ b/index.html
@@ -336,7 +336,8 @@ npm run build-electron-{windows, darwin, linux}</pre>
               <td class="prefix"><span ng-class="::{'repeated-prefix': bufferline.prefixtext==bufferlines[$index-1].prefixtext}"><a ng-click="addMention(bufferline)"><span class="hidden-bracket" ng-if="::(bufferline.showHiddenBrackets)">&lt;</span><span ng-repeat="part in ::bufferline.prefix" ng-class="::part.classes" ng-bind="::part.text|prefixlimit:25"></span><span class="hidden-bracket" ng-if="::(bufferline.showHiddenBrackets)">&gt;</span></a></span></td><!--
            --><td class="message"><!--
              --><div ng-repeat="metadata in ::bufferline.metadata" plugin data="::metadata"></div><!--
-             --><span ng-repeat="part in ::bufferline.content" class="text" ng-class="::part.classes.concat(['line-' + part.$$hashKey.replace(':','_')])" ng-bind-html="::part.text | linky:'_blank':{rel:'noopener noreferrer'} | DOMfilter:'irclinky' | DOMfilter:'emojify':settings.enableJSEmoji | DOMfilter:'inlinecolour' | DOMfilter:'latexmath':('.line-' + part.$$hashKey.replace(':','_')):settings.enableMathjax"></span>
+             --><span ng-repeat="part in ::bufferline.content" class="text" ng-class="::part.classes.concat(['line-' + part.$$hashKey.replace(':','_')])" ng-bind-html="::part.text | conditionalLinkify:part.classes.includes('cof-chat_host') | DOMfilter:'irclinky' | DOMfilter:'emojify':settings.enableJSEmoji | DOMfilter:'inlinecolour' | DOMfilter:'latexmath':('.line-' + part.$$hashKey.replace(':','_')):settings.enableMathjax"></span>
+             <!-- <pre>{{bufferline | json}}</pre> -->
               </td>
             </tr>
             <tr class="readmarker" ng-if="activeBuffer().lastSeen==$index">

--- a/js/filters.js
+++ b/js/filters.js
@@ -59,6 +59,17 @@ weechat.filter('inlinecolour', function() {
     };
 });
 
+// Calls the 'linky' filter unless the disable flag is set. Useful for things like join/quit messages,
+// so you don't accidentally click a mailto: on someone's hostmask.
+weechat.filter('conditionalLinkify', ['$filter', function($filter) {
+    return function(text, disable) {
+        if (!text || disable) {
+            return text;
+        }
+        return $filter('linky')(text, '_blank', {rel:'noopener noreferrer'});
+    };
+}]);
+
 // apply a filter to an HTML string's text nodes, and do so with not exceedingly terrible performance
 weechat.filter('DOMfilter', ['$filter', '$sce', function($filter, $sce) {
     // To prevent nested anchors, we need to know if a filter is going to create them.


### PR DESCRIPTION
This adds a conditional `linky` filter, and won't be called for join/part hostnames. Accidentally clicking a `mailto:` link when someone joins a channel on my phone got fairly frustrating, so this seems to be a reasonable solution. This should resolve issue #1011.

 I'm looking for the `cof-chat_host` class, rather than looking for an `irc_join`/etc tag, as the class method lets things like URLs in quit messages get linkified, while not linkifying hostnames. I'll re-work this if there's a better way.

Unconditional linky:
![image](https://user-images.githubusercontent.com/176014/56073923-7c0a0180-5d78-11e9-8dd0-ee56551f650d.png)


Conditional linky:
![image](https://user-images.githubusercontent.com/176014/56073912-6c8ab880-5d78-11e9-9628-a8d327345b2e.png)
