### PR TITLE
Add Gopher support to UrlPlugin

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -23,7 +23,7 @@ var Plugin = function(name, contentForMessage) {
 
 
 // Regular expression that detects URLs for UrlPlugin
-var urlRegexp = /(?:(?:https?|ftp):\/\/|www\.|ftp\.)\S*[^\s.;,(){}<>]/g;
+var urlRegexp = /(?:(?:https?|ftp|gopher):\/\/|www\.|ftp\.)\S*[^\s.;,(){}<>]/g;
 /*
  * Definition of a user provided plugin that consumes URLs
  *


### PR DESCRIPTION
Untested. Given that it currently ostensibly supports ftp-based links, this should add equal-level support for gopher links.