### PR TITLE
Add settings option to toggle codify filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,7 +336,7 @@ npm run build-electron-{windows, darwin, linux}</pre>
               <td class="prefix"><span ng-class="::{'repeated-prefix': bufferline.prefixtext==bufferlines[$index-1].prefixtext}"><a ng-click="addMention(bufferline)"><span class="hidden-bracket" ng-if="::(bufferline.showHiddenBrackets)">&lt;</span><span ng-repeat="part in ::bufferline.prefix" ng-class="::part.classes" ng-bind="::part.text|prefixlimit:25"></span><span class="hidden-bracket" ng-if="::(bufferline.showHiddenBrackets)">&gt;</span></a></span></td><!--
            --><td class="message"><!--
              --><div ng-repeat="metadata in ::bufferline.metadata" plugin data="::metadata"></div><!--
-             --><span ng-repeat="part in ::bufferline.content" class="text" ng-class="::part.classes.concat(['line-' + part.$$hashKey.replace(':','_')])" ng-bind-html="::part.text | conditionalLinkify:part.classes.includes('cof-chat_host') | codify | DOMfilter:'irclinky' | DOMfilter:'emojify':settings.enableJSEmoji | DOMfilter:'inlinecolour' |  DOMfilter:'latexmath':('.line-' + part.$$hashKey.replace(':','_')):settings.enableMathjax"></span>
+             --><span ng-repeat="part in ::bufferline.content" class="text" ng-class="::part.classes.concat(['line-' + part.$$hashKey.replace(':','_')])" ng-bind-html="::part.text | conditionalLinkify:part.classes.includes('cof-chat_host') | codify:settings.enableCodify | DOMfilter:'irclinky' | DOMfilter:'emojify':settings.enableJSEmoji | DOMfilter:'inlinecolour' |  DOMfilter:'latexmath':('.line-' + part.$$hashKey.replace(':','_')):settings.enableMathjax"></span>
               </td>
             </tr>
             <tr class="readmarker" ng-if="activeBuffer().lastSeen==$index">
@@ -502,6 +502,16 @@ npm run build-electron-{windows, darwin, linux}</pre>
                     <label>
                       <input type="checkbox" ng-model="settings.enableJSEmoji">
                       Enable non-native Emoji support <span class="text-muted settings-help">Displays Emoji characters as images. Emoji provided free by <a href="http://emojione.com">http://emojione.com</a></span>
+                    </label>
+                  </div>
+                </form>
+              </li>
+              <li>
+                <form class="form-inline" role="form">
+                  <div class="checkbox">
+                    <label>
+                      <input type="checkbox" ng-model="settings.enableCodify">
+                      Enable code highlighting using backticks
                     </label>
                   </div>
                 </form>

--- a/js/filters.js
+++ b/js/filters.js
@@ -239,6 +239,11 @@ weechat.filter('prefixlimit', function() {
 
 weechat.filter('codify', function() {
     return function(text) {
+        // hacky way of making codify callable with one argument or two -
+        // the second being "enabled"
+        if (arguments.length >= 2 && !arguments[1]) {
+            return text;
+        }
         var re = /`(.+?)`/g;
         return text.replace(re, function(match, code) {
             var rr = '<span class="hidden-bracket">`</span><code>' + code + '</code><span class="hidden-bracket">`</span>';

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -60,6 +60,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         'enableJSEmoji': !utils.isMobileUi(),
         'enableMathjax': false,
         'enableQuickKeys': true,
+        'enableCodify': true,
         'customCSS': '',
         "currentlyViewedBuffers":{},
     });

--- a/test/unit/filters.js
+++ b/test/unit/filters.js
@@ -114,6 +114,12 @@ describe('Filters', function() {
             expect(codifyFilter('foo`bar')).toEqual('foo`bar');
         }));
 
-        
+        it('should not codify when disabled', inject(function(codifyFilter) {
+            expect(codifyFilter('z `foo` z', false)).toEqual('z `foo` z');
+        }));
+
+        it('should codify when enabled', inject(function(codifyFilter) {
+            expect(codifyFilter('z `foo` z', true)).toEqual('z <span class="hidden-bracket">`</span><code>foo</code><span class="hidden-bracket">`</span> z');
+        }));
     });
 });


### PR DESCRIPTION
This PR implements a settings option to toggle the `codify` filter on and off, similar to the settings for the `emojify` and the `latexmath` filters. The option defaults to on, which retains the default behaviour before this PR.

I personally prefer to keep the `codify` filter off, as it visually modifies the content of the message (removing backticks). The `codify` filter also causes some unexpected behaviour when viewing text with backticks, such as <code>&#96;&#96;fancy'' &#96;&#96;quotes''</code> or <code>http://google.com/`weird`</code> - that last one is probably a bug.