### PR TITLE
Improve codify filter

### DIFF
--- a/css/themes/dark.css
+++ b/css/themes/dark.css
@@ -2114,6 +2114,11 @@ button.close:hover {
     font-weight: bold;
 }
 
+code {
+  background-color: #444;
+  color: #fff;
+}
+
 /* */
 /* Mobile layout */
 /* */

--- a/index.html
+++ b/index.html
@@ -336,7 +336,7 @@ npm run build-electron-{windows, darwin, linux}</pre>
               <td class="prefix"><span ng-class="::{'repeated-prefix': bufferline.prefixtext==bufferlines[$index-1].prefixtext}"><a ng-click="addMention(bufferline)"><span class="hidden-bracket" ng-if="::(bufferline.showHiddenBrackets)">&lt;</span><span ng-repeat="part in ::bufferline.prefix" ng-class="::part.classes" ng-bind="::part.text|prefixlimit:25"></span><span class="hidden-bracket" ng-if="::(bufferline.showHiddenBrackets)">&gt;</span></a></span></td><!--
            --><td class="message"><!--
              --><div ng-repeat="metadata in ::bufferline.metadata" plugin data="::metadata"></div><!--
-             --><span ng-repeat="part in ::bufferline.content" class="text" ng-class="::part.classes.concat(['line-' + part.$$hashKey.replace(':','_')])" ng-bind-html="::part.text | conditionalLinkify:part.classes.includes('cof-chat_host') | codify | DOMfilter:'irclinky' | DOMfilter:'emojify':settings.enableJSEmoji | DOMfilter:'inlinecolour' |  DOMfilter:'latexmath':('.line-' + part.$$hashKey.replace(':','_')):settings.enableMathjax"></span>
+             --><span ng-repeat="part in ::bufferline.content" class="text" ng-class="::part.classes.concat(['line-' + part.$$hashKey.replace(':','_')])" ng-bind-html="::part.text | conditionalLinkify:part.classes.includes('cof-chat_host') | DOMfilter:'codify' | DOMfilter:'irclinky' | DOMfilter:'emojify':settings.enableJSEmoji | DOMfilter:'inlinecolour' |  DOMfilter:'latexmath':('.line-' + part.$$hashKey.replace(':','_')):settings.enableMathjax"></span>
               </td>
             </tr>
             <tr class="readmarker" ng-if="activeBuffer().lastSeen==$index">

--- a/js/filters.js
+++ b/js/filters.js
@@ -239,9 +239,14 @@ weechat.filter('prefixlimit', function() {
 
 weechat.filter('codify', function() {
     return function(text) {
-        var re = /(^|\s)`(.+?)`/g;
-        return text.replace(re, function(match, ws, code) {
-            var rr = ws + '<span class="hidden-bracket">`</span><code>' + code + '</code><span class="hidden-bracket">`</span>';
+        // The groups of this regex are:
+        // 1. Start of line or space, to prevent codifying weird`stuff` like this
+        // 2. Opening single or triple backticks (not 2, not more than 3)
+        // 3. The code block, does not start with another backtick, non-greedy expansion
+        // 4. The closing backticks, identical to group 2
+        var re = /(^|\s)(```|`)([^`].*?)\2/g;
+        return text.replace(re, function(match, ws, open, code) {
+            var rr = ws + '<span class="hidden-bracket">' + open + '</span><code>' + code + '</code><span class="hidden-bracket">' + open + '</span>';
             return rr;
         });
     };

--- a/js/filters.js
+++ b/js/filters.js
@@ -239,9 +239,9 @@ weechat.filter('prefixlimit', function() {
 
 weechat.filter('codify', function() {
     return function(text) {
-        var re = /`(.+?)`/g;
-        return text.replace(re, function(match, code) {
-            var rr = '<span class="hidden-bracket">`</span><code>' + code + '</code><span class="hidden-bracket">`</span>';
+        var re = /(^|\s)`(.+?)`/g;
+        return text.replace(re, function(match, ws, code) {
+            var rr = ws + '<span class="hidden-bracket">`</span><code>' + code + '</code><span class="hidden-bracket">`</span>';
             return rr;
         });
     };

--- a/test/unit/filters.js
+++ b/test/unit/filters.js
@@ -100,6 +100,8 @@ describe('Filters', function() {
 
         it('should codify single snippets', inject(function(codifyFilter) {
             expect(codifyFilter('z `foo` z')).toEqual('z <span class="hidden-bracket">`</span><code>foo</code><span class="hidden-bracket">`</span> z');
+            expect(codifyFilter('z `a` z')).toEqual('z <span class="hidden-bracket">`</span><code>a</code><span class="hidden-bracket">`</span> z');
+            expect(codifyFilter('z ```foo``` z')).toEqual('z <span class="hidden-bracket">```</span><code>foo</code><span class="hidden-bracket">```</span> z');
         }));
 
         it('should codify multiple snippets', inject(function(codifyFilter) {
@@ -112,6 +114,21 @@ describe('Filters', function() {
 
         it('should not codify single backticks', inject(function(codifyFilter) {
             expect(codifyFilter('foo`bar')).toEqual('foo`bar');
+        }));
+
+
+        it('should not codify double backticks', inject(function(codifyFilter) {
+            expect(codifyFilter('some ``non-code``')).toEqual('some ``non-code``');
+        }));
+
+
+        it('should not codify pseudo-fancy quotes', inject(function(codifyFilter) {
+            expect(codifyFilter('some ``fancy qoutes\'\'')).toEqual('some ``fancy qoutes\'\'');
+        }));
+
+        it('should not codify stuff in the middle of a word or URL', inject(function(codifyFilter) {
+            expect(codifyFilter('https://foo.bar/`wat`')).toEqual('https://foo.bar/`wat`');
+            expect(codifyFilter('Weird`ness`')).toEqual('Weird`ness`');
         }));
 
         


### PR DESCRIPTION
- Only match after whitespace or at the start of the line
- Match triple backticks, too
- Document the new, more complicated regex :)
- Theme the code elements in the dark and black themes
- Add tests to verify that these changes work

Fixes #1058
Supersedes #1057 because it catches all of the cases described therein :)