### PR TITLE
Added option to always show unread count badge in mobile

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -821,6 +821,9 @@ img.emojione {
         display: none;
     }
 
+    #topbar .badge-show {
+        display: inline-block;
+    }
 
     #bufferlines, #nicklist {
         position: relative;

--- a/index.html
+++ b/index.html
@@ -486,7 +486,16 @@ npm run build-electron-{windows, darwin, linux}</pre>
                   </div>
                 </form>
               </li>
-              <li>
+              <li class="mobile">
+                <form class="form-inline" role="form">
+                  <div class="checkbox">
+                    <label>
+                      <input type="checkbox" ng-model="settings.alwaysunreadbadge">
+                      Always show unread count in favicon
+                    </label>
+                  </div>
+                </form>
+              </li>              <li>
                 <form class="form-inline" role="form">
                   <div class="checkbox">
                     <label>

--- a/index.html
+++ b/index.html
@@ -259,8 +259,8 @@ npm run build-electron-{windows, darwin, linux}</pre>
           <a href="#" ng-click="toggleSidebar()">
             <img alt="brand" src="assets/img/favicon.png" title="Connected to {{ settings.host }}:{{ settings.port}}">
           </a>
-          <span class="badge" ng-show="unread > 0">{{unread}}</span>
-          <span class="badge danger" ng-show="notifications > 0">{{notifications}}</span>
+          <span class="badge" ng-class="{'badge-show': showUnreadBadge}" ng-show="unread > 0">{{unread}}</span>
+          <span class="badge danger" ng-class="{'badge-show': showUnreadBadge}" ng-show="notifications > 0">{{notifications}}</span>
 
           <button ng-if="debugMode" ng-click="countWatchers()">Count<br />Watchers</button>
         </div>

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -48,6 +48,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         'autoconnect': false,
         'nonicklist': utils.isMobileUi(),
         'alwaysnicklist': false, // only significant on mobile
+        'alwaysunreadbadge': false, // only significant on mobile
         'noembed': true,
         'onlyUnread': false,
         'hotlistsync': true,
@@ -798,6 +799,18 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
             utils.changeClassStyle('favorite-font', 'fontFamily', settings.fontfamily);
             utils.changeClassStyle('favorite-font', 'fontSize', settings.fontsize);
         }, 0);
+        return true;
+    };
+
+    // Callback for when always show unread badge change occurs
+    settings.addCallback('alwaysunreadbadge', function() {
+        $scope.updateShowUnreadBadge();
+    });
+    $scope.showUnreadBadge = false;
+    // Utility function that template can use to check if unread abdge should be
+    // displayed in the title bar
+    $scope.updateShowUnreadBadge = function() {
+        $scope.showUnreadBadge = $scope.settings.alwaysunreadbadge;
         return true;
     };
 


### PR DESCRIPTION
Created a setting only viewable in mobile that keeps the unread count badge viewable. Currently it does not display in the top-bar when in mobile view, which is a usability issue on a desktop machine when docking to half a monitor.

![gb](https://user-images.githubusercontent.com/971474/69266382-10eb9d80-0b99-11ea-841c-84421dc08201.png)
