### PR TITLE
Don't show a TLS warning when loading locally

### DIFF
--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -104,8 +104,8 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     })();
 
     // Show a TLS warning if GB was loaded over an unencrypted connection,
-    // except for local instances (testing, cordova, or electron)
-    $scope.show_tls_warning = (window.location.protocol !== "https:") &&
+    // except for local instances (local files, testing, cordova, or electron)
+    $scope.show_tls_warning = (["https:", "file:"].indexOf(window.location.protocol) === -1) &&
         (["localhost", "127.0.0.1", "::1"].indexOf(window.location.hostname) === -1) &&
         !window.is_electron && !utils.isCordova();
 


### PR DESCRIPTION
I think that's the second time ever I write JS. I tested the patch and it seems to work, but I'm happy to make changes if that's not the right way to do it.