### PR TITLE
Correctly interpret value for addSpace

### DIFF
--- a/js/irc-utils.js
+++ b/js/irc-utils.js
@@ -119,7 +119,7 @@ IrcUtils.service('IrcUtils', [function() {
             suf = ':';
         }
         // addSpace defaults to true
-        var addSpaceChar = (addSpace === undefined || addSpace === true) ? ' ' : '';
+        var addSpaceChar = (addSpace === undefined || addSpace === 'on') ? ' ' : '';
 
         // new nick list to search in
         var searchNickList = _ciNickList(nickList);


### PR DESCRIPTION
This value is not a boolean. Either do it like this, or parse the values correctly when getting the values. This is one in https://github.com/glowing-bear/glowing-bear/blob/master/js/handlers.js#L16

Not sure which makes more sense. But if you start interpreting booleans, you'd have to do it for all types, and you'd have to go over all the code to check every spot where such values are used.

fixes #1086