### PR TITLE
Remove nicklist when leaving channel and bring it back when needed

### DIFF
--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -149,6 +149,9 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         }, false);
     }
 
+    $rootScope.$on('nickListChanged', function() {
+            $scope.updateShowNicklist();
+    });
 
     $rootScope.$on('activeBufferChanged', function(event, unreadSum) {
         var ab = models.getActiveBuffer();
@@ -776,7 +779,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     $scope.updateShowNicklist = function() {
         var ab = models.getActiveBuffer();
         // Check whether buffer exists and nicklist is non-empty
-        if (!ab || ab.isNicklistEmpty()) {
+        if (!ab || !ab.nicklistRequested() || ab.isNicklistEmpty()) {
             $scope.showNicklist = false;
             return false;
         }

--- a/js/handlers.js
+++ b/js/handlers.js
@@ -431,12 +431,24 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
 
     /*
      * Handle nicklist event
+     *
+     * This event can either fill or clear a nicklist. It is always a complete nicklist.
      */
     var handleNicklist = function(message) {
         var nicklist = message.objects[0].content;
         var group = 'root';
+
+        //clear the nicklists in case we are clearing
+        if (nicklist.length==1)
+        {
+            models.getBuffer(nicklist[0].pointers[0]).clearNicklist();
+        }
+
+        //fill the nicklist
         nicklist.forEach(function(n) {
             var buffer = models.getBuffer(n.pointers[0]);
+            
+            //buffer nicklist 
             if (n.group === 1) {
                 var g = new models.NickGroup(n);
                 group = g.name;
@@ -446,6 +458,9 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
                 buffer.addNick(group, nick);
             }
         });
+
+        //check if nicklist should be hidden or not
+        $rootScope.$emit('nickListChanged');
     };
     /*
      * Handle nicklist diff event

--- a/js/models.js
+++ b/js/models.js
@@ -155,6 +155,18 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
             */
         };
         /*
+         * Clear the nicklist
+         */
+        var clearNicklist = function() {
+            //only keep the root node
+            for (var obj in nicklist) {
+                if (obj !== 'root') {
+                    delete nicklist[obj]
+                }
+            }
+        };
+
+        /*
          * Updates a nick in nicklist
          */
         var updateNick = function(group, nick) {
@@ -325,6 +337,7 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
             nicklist: nicklist,
             addNick: addNick,
             delNick: delNick,
+            clearNicklist: clearNicklist,
             updateNick: updateNick,
             getNicklistByTime: getNicklistByTime,
             serverSortKey: serverSortKey,

--- a/js/models.js
+++ b/js/models.js
@@ -161,7 +161,7 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
             //only keep the root node
             for (var obj in nicklist) {
                 if (obj !== 'root') {
-                    delete nicklist[obj]
+                    delete nicklist[obj];
                 }
             }
         };


### PR DESCRIPTION
Fixes #1088 

Please feel free to correct my code and style, etc. I tried to touch as little as possible but had to go further than I wanted it to. Nonetheless I think it's a pretty clean solution and it actually brings a nice feature, The nicklist should really dissapear when you are not joined in a channel.

Tested well in desktop chrome but did not have a chance to do it on mobile or electron.