### PR TITLE
Allow specifying custom websocket path in host field

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -932,7 +932,3 @@ code {
     color: #444;
     border: 1pt solid #444;
 }
-
-.form-control[disabled] {
-    background-color: #555;
-}

--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -932,3 +932,7 @@ code {
     color: #444;
     border: 1pt solid #444;
 }
+
+.form-control[disabled] {
+    background-color: #555;
+}

--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -610,7 +610,6 @@ h2 span, h2 small {
 
 .panel[data-state=active] .panel-collapse {
     transition: max-height 0.5s;
-    max-height: 60em;
     height: auto;
     display: block;
 }

--- a/css/themes/base16-default.css
+++ b/css/themes/base16-default.css
@@ -301,6 +301,9 @@ tr.bufferline:hover {
 input[type=text], input[type=password], #sendMessage, .badge {
     box-shadow: 0px 1px 0px rgba(255, 255, 255, 0.1), 0px 1px 7px 0px rgba(0, 0, 0, 0.2) inset;
 }
+input[type=text].is-invalid{
+    box-shadow: 0px 1px 0px rgba(255, 255, 255, 0.1), 0px 1px 7px 0px rgba(255, 0, 0, 0.6) inset;
+}
 
 input[type=text], input[type=password], #sendMessage, .btn-send, .btn-send-image, .btn-complete-nick {
     color: var(--base05);

--- a/css/themes/base16-default.css
+++ b/css/themes/base16-default.css
@@ -65,6 +65,10 @@ a:visited:hover, a:visited:active, a:visited:focus {
     border: 0px none;
 }
 
+.form-control[disabled] {
+    background: var(--base03);
+}
+
 .form-control:focus {
     color: var(--base06);
     box-shadow: 0px 1px 0px rgba(255, 255, 255, 0.1), 0px 1px 7px 0px rgba(0, 0, 0, 0.2) inset;

--- a/css/themes/dark.css
+++ b/css/themes/dark.css
@@ -10,6 +10,10 @@ body {
     border: 0px none;
 }
 
+.form-control[disabled] {
+    background: none repeat scroll 0% 0% rgba(63, 63, 63, 0.3);
+}
+
 .form-control option {
    color: #eee;
    background: #282828;

--- a/css/themes/dark.css
+++ b/css/themes/dark.css
@@ -86,6 +86,9 @@ input[type=text], input[type=password], #sendMessage, .badge, .btn-send, .btn-se
     color: #ccc;
     background: none repeat scroll 0% 0% rgba(0, 0, 0, 0.3);
 }
+input[type=text].is-invalid{
+    box-shadow: 0px 1px 0px rgba(255, 255, 255, 0.1), 0px 1px 7px 0px rgba(255, 0, 0, 0.8) inset;
+}
 
 .btn-complete-nick:hover, .btn-complete-nick:focus,
 .btn-send:hover, .btn-send:focus,

--- a/css/themes/light.css
+++ b/css/themes/light.css
@@ -68,6 +68,11 @@ select.form-control, select option, input[type=text], input[type=password], #sen
     box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.1), 0px 1px 7px 0px rgba(255, 255, 255, 0.8) inset;
     background: none repeat scroll 0% 0% rgba(255, 255, 255, 0.3);
 }
+
+.form-control[disabled] {
+    background: none repeat scroll 0% 0% rgba(134, 134, 134, 0.3);
+}
+
 input[type=text].is-invalid{
     box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.1), 0px 1px 7px 0px rgba(255, 0, 0, 0.8) inset;
 }

--- a/css/themes/light.css
+++ b/css/themes/light.css
@@ -68,6 +68,9 @@ select.form-control, select option, input[type=text], input[type=password], #sen
     box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.1), 0px 1px 7px 0px rgba(255, 255, 255, 0.8) inset;
     background: none repeat scroll 0% 0% rgba(255, 255, 255, 0.3);
 }
+input[type=text].is-invalid{
+    box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.1), 0px 1px 7px 0px rgba(255, 0, 0, 0.8) inset;
+}
 
 #connection-infos {
     color: #aaa;

--- a/index.html
+++ b/index.html
@@ -111,6 +111,8 @@
                       </div>
                     </div>
                   </div>
+                  <label class="control-label" for="path">WebSocket path</label>
+                  <input type="text" class="form-control favorite-font" id="path" ng-model="settings.path" placeholder="WebSocket path">
                   <label class="control-label" for="password">WeeChat relay password</label>
                   <input type="password" class="form-control favorite-font" id="password" ng-model="password" placeholder="Password">
                   <div class="alert alert-danger" ng-show="passwordError" ng-cloak>

--- a/index.html
+++ b/index.html
@@ -207,10 +207,41 @@ chown -R <strong>username</strong>:<strong>username</strong> ~<strong>username</
               <p>
               Helpful trigger to automatically repin a buffer (in this instance, <var>irc.freenode.#weechat</var>): <pre><code>/trigger add autopin signal "buffer_opened" "${buffer[${tg_signal_data}].full_name} =~ <var>irc.freenode.#weechat</var>" "" "/command -buffer ${buffer[${tg_signal_data}].full_name} * /buffer set localvar_set_pinned true"</code></pre>
               </p>
-              <h3>Setting path</h3>
-              <p>
-                The path is by default 'weechat'. In case a proxy is used the path can be changed by entering it in the host field. For example <code>your.domain.com:8000/otherpath</code>.
+              <h3>Setting a custom path</h3>
+              <p> 
+                To connect to the weechat relay service we connect using a URL. A typical URL consists of 4 parts. <code>{scheme}://{host}:{port}/{path}</code>. The path can be changed by enterying the relay's full URL (except the scheme).
+              </p> 
+                <ul>
+                  <li><b>scheme</b>: The scheme must never be input. The scheme is "ws" if TLS isn't used and it is "wss" if TLS is used.</li>
+                  <li><b>host</b>: Can be an IPv4, IPv6 or a FQDN. IPv6 addresses must be wrapped in square brackets.</li>
+                  <li><b>port</b>: can be specified in the host field or the seperate port field. However if the path is specified in the host field the port must also be specified.</li>
+                  <li><b>path</b>: by defautl this is "weechat". In case <a href="https://github.com/glowing-bear/glowing-bear/wiki/Proxying-WeeChat-relay-with-a-web-server">a proxy</a> is used the path can be changed by entering it in the host field.</li>
+                </ul>
+              <p> 
+                Examples of correct input for the host field are:
               </p>
+                <ul>
+                  <li>192.168.0.1</li>
+                  <li>192.168.0.1:8000</li>
+                  <li>192.168.0.1:8000/weechat2</li>
+                  <li>[2001:db8:85a3::8a2e:370:7334]</li>
+                  <li>[2001:db8:85a3::8a2e:370:7334]:8000</li>
+                  <li>[2001:db8:85a3::8a2e:370:7334]:8000/weechat2</li>
+                  <li>yourhost.yourdomain.com</li>
+                  <li>yourhost.yourdomain.com:8000</li>
+                  <li>yourhost.yourdomain.com:8000/weechat2</li>
+                </ul>
+                <p>
+                  Incorrect input for the host field:
+                </p>
+                <ul>
+                  <li><span class="text-danger">ws://192.168.0.1</span> (do not specify the scheme)</li>
+                  <li><span class="text-danger">192.168.0.1/weechat2</span> (must specify port when specifying path)</li>
+                  <li><span class="text-danger">[2001:db8:85a3::8a2e:370:7334]/weechat2</span> (must specify port when specifying path)</li>
+                  <li><span class="text-danger">yourhost.yourdomain.com/weechat2</span> (must specify port when specifying path)</li>
+                  <li><span class="text-danger">2001:db8:85a3::8a2e:370:7334</span> (must wrap IPv6 address in square brackets)</li>
+                  <li><span class="text-danger">2001:db8:85a3::8a2e:370:7334:8000</span> (must wrap IPv6 address in square brackets)</li>
+                </ul>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
                   <div class="input-group">
                     <div class="row no-gutter">
                       <div class="col-sm-9">
-                        <input type="text" class="form-control favorite-font" id="host" ng-model="settings.host" ng-change="parseHost()" placeholder="Address" autocapitalize="off">
+                        <input type="text" class="form-control favorite-font" id="host" ng-model="settings.host" ng-change="parseHost()" ng-class="{'is-invalid': hostInvalid}" placeholder="Address" autocapitalize="off">
                       </div>
                       <div class="col-sm-3">
                         <input type="text" class="form-control favorite-font" id="port" ng-model="settings.port" ng-disabled="portDisabled" placeholder="Port">
@@ -136,7 +136,7 @@
                     </label>
                   </div>
                 </div>
-                <button class="btn btn-lg btn-primary" ng-click="connect()" ng-cloak>{{ connectbutton }}  <i ng-class="connectbuttonicon" class="glyphicon"></i></button>
+                <button class="btn btn-lg btn-primary" ng-disabled="hostInvalid" ng-click="connect()" ng-cloak>{{ connectbutton }}  <i ng-class="connectbuttonicon" class="glyphicon"></i></button>
               </form>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
                   <div class="input-group">
                     <div class="row no-gutter">
                       <div class="col-sm-9">
-                        <input type="text" class="form-control favorite-font" id="host" ng-model="settings.host" ng-change="parseHost()" ng-class="{'is-invalid': hostInvalid}" placeholder="Address" autocapitalize="off">
+                        <input type="text" class="form-control favorite-font" id="host" ng-model="settings.hostField" ng-change="parseHost()" ng-class="{'is-invalid': hostInvalid}" placeholder="Address" autocapitalize="off">
                       </div>
                       <div class="col-sm-3">
                         <input type="text" class="form-control favorite-font" id="port" ng-model="settings.port" ng-disabled="portDisabled" placeholder="Port">

--- a/index.html
+++ b/index.html
@@ -104,15 +104,13 @@
                   <div class="input-group">
                     <div class="row no-gutter">
                       <div class="col-sm-9">
-                        <input type="text" class="form-control favorite-font" id="host" ng-model="settings.host" placeholder="Address" autocapitalize="off">
+                        <input type="text" class="form-control favorite-font" id="host" ng-model="settings.host" ng-change="parseHost()" placeholder="Address" autocapitalize="off">
                       </div>
                       <div class="col-sm-3">
-                        <input type="text" class="form-control favorite-font" id="port" ng-model="settings.port" placeholder="Port">
+                        <input type="text" class="form-control favorite-font" id="port" ng-model="settings.port" ng-disabled="portDisabled" placeholder="Port">
                       </div>
                     </div>
                   </div>
-                  <label class="control-label" for="path">WebSocket path</label>
-                  <input type="text" class="form-control favorite-font" id="path" ng-model="settings.path" placeholder="WebSocket path">
                   <label class="control-label" for="password">WeeChat relay password</label>
                   <input type="password" class="form-control favorite-font" id="password" ng-model="password" placeholder="Password">
                   <div class="alert alert-danger" ng-show="passwordError" ng-cloak>
@@ -208,6 +206,10 @@ chown -R <strong>username</strong>:<strong>username</strong> ~<strong>username</
               </p>
               <p>
               Helpful trigger to automatically repin a buffer (in this instance, <var>irc.freenode.#weechat</var>): <pre><code>/trigger add autopin signal "buffer_opened" "${buffer[${tg_signal_data}].full_name} =~ <var>irc.freenode.#weechat</var>" "" "/command -buffer ${buffer[${tg_signal_data}].full_name} * /buffer set localvar_set_pinned true"</code></pre>
+              </p>
+              <h3>Setting path</h3>
+              <p>
+                The path is by default 'weechat'. In case a proxy is used the path can be changed by entering it in the host field. For example <code>your.domain.com:8000/otherpath</code>.
               </p>
             </div>
           </div>

--- a/js/bufferResume.js
+++ b/js/bufferResume.js
@@ -11,7 +11,7 @@ var bufferResume = angular.module('bufferResume', []);
 
 bufferResume.service('bufferResume', ['settings', function(settings) {
     var resumer = {};
-    var key = settings.host + ":" + settings.port;
+    var key = settings.host + ":" + settings.port + "/" + settings.path;
 
     // Hold the status that we were able to find the previously accessed buffer
     //   and reload it.  If we cannot, we'll need to know so we can load the default

--- a/js/connection.js
+++ b/js/connection.js
@@ -20,15 +20,15 @@ weechat.factory('connection',
     var locked = false;
 
     // Takes care of the connection and websocket hooks
-    var connect = function (host, port, passwd, ssl, noCompression, successCallback, failCallback) {
+    var connect = function (host, port, path, passwd, ssl, noCompression, successCallback, failCallback) {
         $rootScope.passwordError = false;
-        connectionData = [host, port, passwd, ssl, noCompression];
+        connectionData = [host, port, path, passwd, ssl, noCompression];
         var proto = ssl ? 'wss' : 'ws';
         // If host is an IPv6 literal wrap it in brackets
         if (host.indexOf(":") !== -1 && host[0] !== "[" && host[host.length-1] !== "]") {
             host = "[" + host + "]";
         }
-        var url = proto + "://" + host + ":" + port + "/weechat";
+        var url = proto + "://" + host + ":" + port + "/" + path;
         $log.debug('Connecting to URL: ', url);
 
         var onopen = function () {

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -610,7 +610,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         }
         return connection.fetchMoreLines(numLines);
     };
-
+    
     $scope.infiniteScroll = function() {
         // Check if we are already fetching
         if ($rootScope.loadingLines) {
@@ -630,6 +630,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
             }
             $rootScope.bufferBottom = eob.offsetTop <= bl.scrollTop + bl.clientHeight;
     };
+
     $rootScope.scrollWithBuffer = function(scrollToReadmarker, moreLines) {
         // First, get scrolling status *before* modification
         // This is required to determine where we were in the buffer pre-change
@@ -664,39 +665,31 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     };
 
     $scope.parseHost = function() {
-
         //The host field is multi purpose for advanced users
         //There can be a combination of host, port and path
         //If host is specified here the dedicated port field is disabled
-        var parts;
-
         $rootScope.hostInvalid = false;
 
-        //host
+        var parts;
         var regexHost = /^([^:\/]*|\[.*\])$/;
         var regexHostPort = /^([^:]*|\[.*\]):(\d+)$/;
         var regexHostPortPath = /^([^:]*|\[.*\]):(\d*)\/(.+)$/;
-        if((parts = regexHost.exec(settings.hostField)) !== null) {
+
+        if ((parts = regexHost.exec(settings.hostField)) !== null) { //host only
             settings.host = parts[1];
             $rootScope.portDisabled = false;
-        }
-        //host:port
-        else if((parts = regexHostPort.exec(settings.hostField)) !== null) {
+        } else if ((parts = regexHostPort.exec(settings.hostField)) !== null) { //host:port
             settings.host = parts[1];
             settings.port = parts[2];
             $rootScope.portDisabled = true;
-        }
-        //host:port/path
-        else if((parts = regexHostPortPath.exec(settings.hostField)) !== null) {
+        } else if ((parts = regexHostPortPath.exec(settings.hostField)) !== null) { //host:port/path
             settings.host = parts[1];
             settings.port = parts[2];
             settings.path = parts[3];
             $rootScope.portDisabled = true;
-        }
-        else {
+        } else {
             $rootScope.hostInvalid = true;
         }
-
     };
 
     $scope.connect = function() {
@@ -709,12 +702,14 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         $scope.connectbuttonicon = 'glyphicon-refresh glyphicon-spin';
         connection.connect(settings.host, settings.port, settings.path, $scope.password, settings.ssl);
     };
+
     $scope.disconnect = function() {
         $scope.connectbutton = 'Connect';
         $scope.connectbuttonicon = 'glyphicon-chevron-right';
         bufferResume.reset();
         connection.disconnect();
     };
+    
     $scope.reconnect = function() {
         var bufferId = models.getActiveBuffer().id;
         connection.attemptReconnect(bufferId, 3000);
@@ -723,6 +718,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     $scope.showModal = function(elementId) {
         document.getElementById(elementId).setAttribute('data-state', 'visible');
     };
+
     $scope.closeModal = function($event) {
         function closest(elem, selector) {
             var matchesSelector = elem.matches || elem.webkitMatchesSelector || elem.mozMatchesSelector || elem.msMatchesSelector;

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -610,7 +610,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         }
         return connection.fetchMoreLines(numLines);
     };
-    
+
     $scope.infiniteScroll = function() {
         // Check if we are already fetching
         if ($rootScope.loadingLines) {
@@ -677,10 +677,12 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
 
         if ((parts = regexHost.exec(settings.hostField)) !== null) { //host only
             settings.host = parts[1];
+            settings.path = "weechat";
             $rootScope.portDisabled = false;
         } else if ((parts = regexHostPort.exec(settings.hostField)) !== null) { //host:port
             settings.host = parts[1];
             settings.port = parts[2];
+            settings.path = "weechat";
             $rootScope.portDisabled = true;
         } else if ((parts = regexHostPortPath.exec(settings.hostField)) !== null) { //host:port/path
             settings.host = parts[1];

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -43,6 +43,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         'theme': 'dark',
         'host': 'localhost',
         'port': 9001,
+        'path': 'weechat',
         'ssl': (window.location.protocol === "https:"),
         'savepassword': false,
         'autoconnect': false,
@@ -665,7 +666,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         $rootScope.bufferBottom = true;
         $scope.connectbutton = 'Connecting';
         $scope.connectbuttonicon = 'glyphicon-refresh glyphicon-spin';
-        connection.connect(settings.host, settings.port, $scope.password, settings.ssl);
+        connection.connect(settings.host, settings.port, settings.path, $scope.password, settings.ssl);
     };
     $scope.disconnect = function() {
         $scope.connectbutton = 'Connect';
@@ -933,6 +934,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
             var spl = rawStr.split(":");
             var host = spl[0];
             var port = parseInt(spl[1]);
+            var path = 'weechat';
             var password = spl[2];
             var ssl = spl.length > 3;
             notifications.requestNotificationPermission();
@@ -942,7 +944,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
             $rootScope.bufferBottom = true;
             $scope.connectbutton = 'Connecting';
             $scope.connectbuttonicon = 'glyphicon-chevron-right';
-            connection.connect(host, port, password, ssl);
+            connection.connect(host, port, path, password, ssl);
         }
     };
 

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -41,7 +41,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     // or else they won't be saved to the localStorage.
     settings.setDefaults({
         'theme': 'dark',
-        'host': 'localhost',
+        'hostField': 'localhost',
         'port': 9001,
         'path': 'weechat',
         'ssl': (window.location.protocol === "https:"),
@@ -65,6 +65,12 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         "currentlyViewedBuffers":{},
     });
     $scope.settings = settings;
+
+    //For upgrade reasons because we changed the name of host to hostField
+    //check if the value might still be in the host key instead of the hostField key
+    if (!settings.hostFieldv && settings.host) {
+        settings.hostField = settings.host; 
+    }
 
     $rootScope.countWatchers = function () {
         $log.debug($rootScope.$$watchersCount);
@@ -658,30 +664,31 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     };
 
     $scope.parseHost = function() {
+
         //The host field is multi purpose for advanced users
         //There can be a combination of host, port and path
         //If host is specified here the dedicated port field is disabled
-
         var parts;
+
         $rootScope.hostInvalid = false;
 
         //host
         var regexHost = /^([^:\/]*|\[.*\])$/;
         var regexHostPort = /^([^:]*|\[.*\]):(\d+)$/;
         var regexHostPortPath = /^([^:]*|\[.*\]):(\d*)\/(.+)$/;
-        if((parts = regexHost.exec(settings.host)) !== null) {
-            settings.hostOnly = parts[1];
+        if((parts = regexHost.exec(settings.hostField)) !== null) {
+            settings.host = parts[1];
             $rootScope.portDisabled = false;
         }
         //host:port
-        else if((parts = regexHostPort.exec(settings.host)) !== null) {
-            settings.hostOnly = parts[1];
+        else if((parts = regexHostPort.exec(settings.hostField)) !== null) {
+            settings.host = parts[1];
             settings.port = parts[2];
             $rootScope.portDisabled = true;
         }
         //host:port/path
-        else if((parts = regexHostPortPath.exec(settings.host)) !== null) {
-            settings.hostOnly = parts[1];
+        else if((parts = regexHostPortPath.exec(settings.hostField)) !== null) {
+            settings.host = parts[1];
             settings.port = parts[2];
             settings.path = parts[3];
             $rootScope.portDisabled = true;
@@ -700,7 +707,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         $rootScope.bufferBottom = true;
         $scope.connectbutton = 'Connecting';
         $scope.connectbuttonicon = 'glyphicon-refresh glyphicon-spin';
-        connection.connect(settings.hostOnly, settings.port, settings.path, $scope.password, settings.ssl);
+        connection.connect(settings.host, settings.port, settings.path, $scope.password, settings.ssl);
     };
     $scope.disconnect = function() {
         $scope.connectbutton = 'Connect';

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -68,7 +68,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
 
     //For upgrade reasons because we changed the name of host to hostField
     //check if the value might still be in the host key instead of the hostField key
-    if (!settings.hostFieldv && settings.host) {
+    if (!settings.hostField && settings.host) {
         settings.hostField = settings.host; 
     }
 

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -662,26 +662,26 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         //There can be a combination of host, port and path
         //If host is specified here the dedicated port field is disabled
 
-        let parts;
+        var parts;
 
         //host
-        const regexHost = /^([^:\/]*|\[.*\])$/;
-        const regexHostPort = /^([^:]*|\[.*\]):(\d+)$/;
-        const regexHostPortPath = /^([^:]*|\[.*\]):(\d*)\/(.+)$/;
-        if(parts = regexHost.exec(settings.host))
+        var regexHost = /^([^:\/]*|\[.*\])$/;
+        var regexHostPort = /^([^:]*|\[.*\]):(\d+)$/;
+        var regexHostPortPath = /^([^:]*|\[.*\]):(\d*)\/(.+)$/;
+        if((parts = regexHost.exec(settings.host)) !== null)
         {
             settings.hostOnly = parts[1];
             $rootScope.portDisabled = false;
         }
         //host:port
-        else if(parts = regexHostPort.exec(settings.host))
+        else if((parts = regexHostPort.exec(settings.host)) !== null)
         {
             settings.hostOnly = parts[1];
             settings.port = parts[2];
             $rootScope.portDisabled = true;
         }
         //host:port/path
-        else if(parts = regexHostPortPath.exec(settings.host))
+        else if((parts = regexHostPortPath.exec(settings.host)) !== null)
         {
             settings.hostOnly = parts[1];
             settings.port = parts[2];

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -663,30 +663,31 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         //If host is specified here the dedicated port field is disabled
 
         var parts;
+        $rootScope.hostInvalid = false;
 
         //host
         var regexHost = /^([^:\/]*|\[.*\])$/;
         var regexHostPort = /^([^:]*|\[.*\]):(\d+)$/;
         var regexHostPortPath = /^([^:]*|\[.*\]):(\d*)\/(.+)$/;
-        if((parts = regexHost.exec(settings.host)) !== null)
-        {
+        if((parts = regexHost.exec(settings.host)) !== null) {
             settings.hostOnly = parts[1];
             $rootScope.portDisabled = false;
         }
         //host:port
-        else if((parts = regexHostPort.exec(settings.host)) !== null)
-        {
+        else if((parts = regexHostPort.exec(settings.host)) !== null) {
             settings.hostOnly = parts[1];
             settings.port = parts[2];
             $rootScope.portDisabled = true;
         }
         //host:port/path
-        else if((parts = regexHostPortPath.exec(settings.host)) !== null)
-        {
+        else if((parts = regexHostPortPath.exec(settings.host)) !== null) {
             settings.hostOnly = parts[1];
             settings.port = parts[2];
             settings.path = parts[3];
             $rootScope.portDisabled = true;
+        }
+        else {
+            $rootScope.hostInvalid = true;
         }
 
     };


### PR DESCRIPTION
- Makes the host field into a multi purpose field as suggested in #1008.
- Disables the port input if it's already specifed in the host field.
- Preserves saved settings, shouldn't break on update
- Added a paragraph in the usage instructions
- Change how the bg color of disabled inputs, it was too white. Not sure if this has in influence on custom styling and such.
- Tested with strings:
```
192.168.0.1:8000
192.168.0.1:8000/weechat2
192.168.0.1
[2001:0db8:85a3:0000:0000:8a2e:0370:7334]
2001:0db8:85a3:0000:0000:8a2e:0370:7334 (does not work, intentionally)
2001:0db8:85a3:0000:0000:8a2e:0370:7334/weechat2  (does not work, intentionally)
[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:8000
[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:8000/weechat2
test.com
test.com:8000
test.com:8000/weechat2
```

resolves #1008

(I'm new to this. There's some extra commits in my pull request that were due to me updating my own downstream branch. I'm not sure if those commits need to be deleted or not.)
