### PR TITLE
Fix plugins freeze title

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -463,8 +463,10 @@ plugins.factory('userPlugins', function() {
                 jsonp(url, function(data) {
                     // Add the gist stylesheet only once
                     if (document.querySelectorAll('link[rel=stylesheet][href="' + data.stylesheet + '"]').length < 1) {
-                        var stylesheet = '<link rel="stylesheet" href="' + data.stylesheet + '"></link>';
-                        document.getElementsByTagName('head')[0].innerHTML += stylesheet;
+                        var stylesheet = document.createElement("link");
+                        stylesheet.href = data.stylesheet;
+                        stylesheet.setAttribute('rel', 'stylesheet');
+                        document.head.appendChild(stylesheet);
                     }
                     element.innerHTML = '<div style="clear:both">' + data.div + '</div>';
                 });


### PR DESCRIPTION
Add stylesheets of plugins in a different way. Doing with with innerHTML causes the dom to unload and reload, apparently this breaks angular. Also this caused a visible fuckup of the screen whenever a plugin was loaded.

Checked to see if other places used this method of adding but seems to only be with GitHub gists.

Fixes #997 