### PR TITLE
Hide sidebar for all widths according to state and correctly apply state

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -263,6 +263,11 @@ input[type=text], input[type=password], #sendMessage {
 #sidebar.ng-hide {
   width: 0;
 }
+    
+#sidebar[data-state=hidden] {
+    transform: translate(-200px,0);
+    -webkit-transform: translate(-200px,0);
+}
 
 #nicklist {
     position: fixed;
@@ -400,6 +405,7 @@ td.time {
     margin-left: 0;
     padding-left: 145px;
 }
+
 .footer.withnicklist {
     padding-right: 100px;
 }
@@ -792,11 +798,6 @@ img.emojione {
     #sidebar[data-state=visible] {
         transform: translate(0,0);
         -webkit-transform: translate(0,0); /* Safari */
-    }
-
-    #sidebar[data-state=hidden] {
-        transform: translate(-200px,0);
-        -webkit-transform: translate(-200px,0);
     }
 
     .content[sidebar-state=visible] #bufferlines, .content[sidebar-state=visible] .footer {

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -576,12 +576,10 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         // Recalculation fails when not connected
         if ($rootScope.connected) {
             // Show the sidebar if switching away from mobile view, hide it when switching to mobile
-            // Wrap in a condition so we save ourselves the $apply if nothing changes (50ms or more)
-            if ($scope.wasMobileUi && !utils.isMobileUi()) {
+            if (!utils.isMobileUi()) {
                 $scope.showSidebar();
                 $scope.updateShowNicklist();
             }
-            $scope.wasMobileUi = utils.isMobileUi();
             $scope.calculateNumLines();
 
             // if we're scrolled to the bottom, scroll down to the same position after the resize

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -319,11 +319,6 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         }
     });
 
-    $rootScope.wasMobileUi = false;
-    if (utils.isMobileUi()) {
-        $rootScope.wasMobileUi = true;
-    }
-
     if (!settings.fontfamily) {
         if (utils.isMobileUi()) {
             settings.fontfamily = 'sans-serif';


### PR DESCRIPTION
Fixes #1094 

Change in the CSS is because the sidebar should always be hidden if the state is hidden, not only for narrow windows.

Change wasMobileUi check when showing sidebar because this was sometimes incorrect when rapidly resizing windows like what happens when dragging a tab in chrome.

Doesn't seem to have a performance impact on desktop, did not check on mobile. I don't think the performance impact can be that much from setting a few of attributes.