### PR TITLE
Fix atob error, add url params

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
                       Encryption. <strong>Strongly recommended!</strong> Need help? Check below.
                     </label>
                   </div>
-                  <div class="checkbox" ng-show="settings.savepassword">
+                  <div class="checkbox" ng-show="settings.savepassword || settings.autoconnect">
                     <label class="control-label" for="autoconnect">
                         <input type="checkbox" id="autoconnect" ng-model="settings.autoconnect"  ng-disabled="settings.useTotp">
                         Automatically connect

--- a/index.html
+++ b/index.html
@@ -270,7 +270,7 @@ chown -R <strong>username</strong>:<strong>username</strong> ~<strong>username</
                 <h3>URL Parameters</h3>
                 <p>
                   Parameters can be passed in the URL to prefill the fields. This can be useful when you have multiple relays and want to use bookmarks to manage them.
-                  We do not recommend passing the password in this was as it will be visible in plain text and stored in the bookmark but it is possible. Special characters should be <a href="https://www.w3schools.com/tags/ref_urlencode.asp">URL encoded</a>.
+                  We do not recommend passing the password in this way as it will be visible in plain text and stored in history/bookmarks but it is possible. Special characters should be <a href="https://www.w3schools.com/tags/ref_urlencode.asp">URL encoded</a>.
                 </p>
                 <p>
                   If we want just the path for example: <code>https://glowing-bear.org/?path=weechat2</code>

--- a/index.html
+++ b/index.html
@@ -272,10 +272,10 @@ chown -R <strong>username</strong>:<strong>username</strong> ~<strong>username</
                   We do not recommend passing the password in this way as it will be visible in plain text and stored in history/bookmarks but it is possible. Special characters should be <a href="https://www.w3schools.com/tags/ref_urlencode.asp">URL encoded</a>.
                 </p>
                 <p>
-                  If we want just the path for example: <code>https://glowing-bear.org/?path=weechat2</code>
+                  If we want just the path for example: <code>https://glowing-bear.org/#path=weechat2</code>
                 </p>
                 <p>
-                  An example: <code>https://glowing-bear.org/?host=my.domain.com&port=8000&password=hunter2&autoconnect=true</code>
+                  An example: <code>https://glowing-bear.org/#host=my.domain.com&port=8000&password=hunter2&autoconnect=true</code>
                 </p>
                 <p>
                   Available parameters:

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <meta http-equiv="x-dns-prefetch-control" content="off">
     <!-- https://w3c.github.io/manifest/ && https://developer.mozilla.org/en-US/docs/Web/Manifest -->
     <link rel="manifest" href="webapp.manifest.json">
+    <base href="/">
     <title ng-bind-template="{{ notificationStatus }}Glowing Bear {{ pageTitle}}"></title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
     <link rel="shortcut icon" sizes="128x128" href="assets/img/glowing_bear_128x128.png">
@@ -230,7 +231,10 @@ chown -R <strong>username</strong>:<strong>username</strong> ~<strong>username</
               </p>
               <h3>Setting a custom path</h3>
               <p> 
-                To connect to the weechat relay service we connect using a URL. A typical URL consists of 4 parts. <code>{scheme}://{host}:{port}/{path}</code>. The path can be changed by enterying the relay's full URL (except the scheme).
+                The hostname field can be used to set a custom path. Or a URL parameter can be used see section 'URL Parameters'. 
+              </p>
+              <p>
+                To connect to the weechat relay service we connect using a URL. A typical URL consists of 4 parts. <code>{scheme}://{host}:{port}/{path}</code>. The path can be changed by entering the relay's full URL (except the scheme).
               </p> 
                 <ul>
                   <li><b>scheme</b>: The scheme must never be input. The scheme is "ws" if TLS isn't used and it is "wss" if TLS is used.</li>
@@ -263,6 +267,27 @@ chown -R <strong>username</strong>:<strong>username</strong> ~<strong>username</
                   <li><span class="text-danger">2001:db8:85a3::8a2e:370:7334</span> (must wrap IPv6 address in square brackets)</li>
                   <li><span class="text-danger">2001:db8:85a3::8a2e:370:7334:8000</span> (must wrap IPv6 address in square brackets)</li>
                 </ul>
+                <h3>URL Parameters</h3>
+                <p>
+                  Parameters can be passed in the URL to prefill the fields. This can be useful when you have multiple relays and want to use bookmarks to manage them.
+                  We do not recommend passing the password in this was as it will be visible in plain text and stored in the bookmark but it is possible. Special characters should be <a href="https://www.w3schools.com/tags/ref_urlencode.asp">URL encoded</a>.
+                </p>
+                <p>
+                  If we want just the path for example: <code>https://glowing-bear.org/?path=weechat2</code>
+                </p>
+                <p>
+                  An example: <code>https://glowing-bear.org/?host=my.domain.com&port=8000&password=hunter2&autoconnect=true</code>
+                </p>
+                <p>
+                  Available parameters:
+                  <ul>
+                    <li>host</li>
+                    <li>port</li>
+                    <li>path</li>
+                    <li>password</li>
+                    <li>autoconnect</li>
+                  </ul>
+                </p>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
     <meta http-equiv="x-dns-prefetch-control" content="off">
     <!-- https://w3c.github.io/manifest/ && https://developer.mozilla.org/en-US/docs/Web/Manifest -->
     <link rel="manifest" href="webapp.manifest.json">
-    <base href="/">
     <title ng-bind-template="{{ notificationStatus }}Glowing Bear {{ pageTitle}}"></title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
     <link rel="shortcut icon" sizes="128x128" href="assets/img/glowing_bear_128x128.png">

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -11,12 +11,6 @@ document.addEventListener("deviceready", function () {
 var weechat = angular.module('weechat', ['ngRoute', 'localStorage', 'weechatModels', 'bufferResume', 'plugins', 'IrcUtils', 'ngSanitize', 'ngWebsockets', 'ngTouch'], ['$compileProvider', '$locationProvider', function($compileProvider, $locationProvider) {
     // hacky way to be able to find out if we're in debug mode
     weechat.compileProvider = $compileProvider;
-
-    //remove hashbang from url
-    $locationProvider.html5Mode({
-        enabled: true,
-        requireBase: false
-    }).hashPrefix('');
 }]);
 weechat.config(['$compileProvider', function ($compileProvider) {
     // hack to determine whether we're executing the tests
@@ -988,30 +982,22 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         if($location.search().password) { $scope.settings.password = $location.search().password;}
         if($location.search().autoconnect) { $scope.settings.autoconnect = $location.search().autoconnect === 'true';}
 
-        if (window.location.hash) {
-            notifications.requestNotificationPermission();
-            $rootScope.sslError = false;
-            $rootScope.securityError = false;
-            $rootScope.errorMessage = false;
-            $rootScope.bufferBottom = true;
-            $scope.connectbutton = 'Connecting';
-            $scope.connectbuttonicon = 'glyphicon-chevron-right';
-            connection.connect(settings.host, settings.port, settings.path, password, ssl);
-        }
     };
 
 }]);
 
-weechat.config(['$routeProvider',
-    function($routeProvider) {
+weechat.config(['$routeProvider', '$locationProvider',
+    function($routeProvider, $locationProvider) {
         $routeProvider.when('/', {
             templateUrl: 'index.html',
             controller: 'WeechatCtrl'
-        })
-        //for legacy reasons redirect the /#! to /
-        .otherwise({
-          redirectTo: '/'
         });
+
+        //remove hashbang from url
+        $locationProvider.html5Mode({
+            enabled: true,
+            requireBase: false
+        }).hashPrefix('');
     }
 ]);
 

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -706,11 +706,23 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
             var segs = val.split('=');
             params[segs[0]] = segs[1];
         });
-        if(params.host) { $scope.settings.host = params.host; $scope.settings.hostField = params.host; }
-        if(params.port) { $scope.settings.port =  parseInt(params.port); }
-        if(params.path) { $scope.settings.path = params.path; $scope.settings.hostField = $scope.settings.host + ":" + $scope.settings.port + "/" + $scope.settings.path; }
-        if(params.password) { $scope.password = params.password; }
-        if(params.autoconnect) { $scope.settings.autoconnect = params.autoconnect === 'true'; }
+        if (params.host) {
+            $scope.settings.host = params.host;
+            $scope.settings.hostField = params.host;
+        }
+        if (params.port) {
+            $scope.settings.port =  parseInt(params.port);
+        }
+        if (params.path) {
+            $scope.settings.path = params.path;
+            $scope.settings.hostField = $scope.settings.host + ":" + $scope.settings.port + "/" + $scope.settings.path;
+        }
+        if (params.password) {
+            $scope.password = params.password;
+        }
+        if (params.autoconnect) {
+            $scope.settings.autoconnect = params.autoconnect === 'true';
+        }
 
     };
 

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -8,7 +8,7 @@ document.addEventListener("deviceready", function () {
     }
 }, false);
 
-var weechat = angular.module('weechat', ['ngRoute', 'localStorage', 'weechatModels', 'bufferResume', 'plugins', 'IrcUtils', 'ngSanitize', 'ngWebsockets', 'ngTouch'], ['$compileProvider', '$locationProvider', function($compileProvider, $locationProvider) {
+var weechat = angular.module('weechat', ['ngRoute', 'localStorage', 'weechatModels', 'bufferResume', 'plugins', 'IrcUtils', 'ngSanitize', 'ngWebsockets', 'ngTouch'], ['$compileProvider', function($compileProvider) {
     // hacky way to be able to find out if we're in debug mode
     weechat.compileProvider = $compileProvider;
 }]);
@@ -22,6 +22,8 @@ weechat.config(['$compileProvider', function ($compileProvider) {
 weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout','$location', '$log', 'models', 'bufferResume', 'connection', 'notifications', 'utils', 'settings',
     function ($rootScope, $scope, $store, $timeout, $location, $log, models, bufferResume, connection, notifications, utils, settings)
 {
+
+    $location.path(window.location.pathname);
 
     window.openBuffer = function(channel) {
         $scope.openBuffer(channel);

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -701,7 +701,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     $scope.parseHash = function() {
 
         //Fill in url parameters, they take precedence over the stored settings, but store them
-        var params = $location.$$hash.split('&').map(function(val) {return {key: val.split('=')[0], value: val.split('=')[1]}});
+        var params = $location.$$hash.split('&').map(function(val) { return {key: val.split('=')[0], value: val.split('=')[1]}; });
         var hostParam = params.find(function(p) { return p.key === 'host'; });
         var portParam = params.find(function(p) { return p.key === 'port'; });
         var pathParam = params.find(function(p) { return p.key === 'path'; });

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -698,6 +698,22 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         $scope.totpInvalid = !/^\d{4,10}$/.test($scope.totp);
     };
 
+    $scope.parseHash = function() {
+
+        //Fill in url parameters, they take precedence over the stored settings, but store them
+        var params = $location.$$hash.split('&').map(function(val) {return {key: val.split('=')[0], value: val.split('=')[1]}});
+        var hostParam = params.find(function(p) { return p.key === 'host'; });
+        var portParam = params.find(function(p) { return p.key === 'port'; });
+        var pathParam = params.find(function(p) { return p.key === 'path'; });
+        var passwordParam = params.find(function(p) { return p.key === 'password'; });
+        var autoconnectParam = params.find(function(p) { return p.key === 'autoconnect'; });
+        if(hostParam) { $scope.settings.host = hostParam.value; $scope.settings.hostField = hostParam.value;}
+        if(portParam) { $scope.settings.port =  parseInt(portParam.value);}
+        if(pathParam) { $scope.settings.path = pathParam.value;}
+        if(passwordParam) { $scope.settings.password = passwordParam.value;}
+        if(autoconnectParam) { $scope.settings.autoconnect = autoconnectParam.value === 'true';}
+    };
+
     $scope.connect = function() {
 
         notifications.requestNotificationPermission();
@@ -972,23 +988,21 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         }
     };
 
+    window.onhashchange = function() {
+        console.log('hash has changed');
+        $scope.parseHash();
+    };
+
     $scope.init = function() {
         $scope.parseHost();
-
-        //Fill in url parameters, they take precedence over the stored settings, but store them
-        if($location.search().host) { $scope.settings.host = $location.search().host; $scope.settings.hostField = $location.search().host;}
-        if($location.search().port) { $scope.settings.port =  parseInt($location.search().port);}
-        if($location.search().path) { $scope.settings.path = $location.search().path;}
-        if($location.search().password) { $scope.settings.password = $location.search().password;}
-        if($location.search().autoconnect) { $scope.settings.autoconnect = $location.search().autoconnect === 'true';}
-
+        $scope.parseHash();
     };
 
 }]);
 
 weechat.config(['$routeProvider', '$locationProvider',
     function($routeProvider, $locationProvider) {
-        $routeProvider.when('/', {
+        $routeProvider.when('', {
             templateUrl: 'index.html',
             controller: 'WeechatCtrl'
         });
@@ -997,7 +1011,7 @@ weechat.config(['$routeProvider', '$locationProvider',
         $locationProvider.html5Mode({
             enabled: true,
             requireBase: false
-        }).hashPrefix('');
+        });
     }
 ]);
 

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -989,7 +989,6 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     };
 
     window.onhashchange = function() {
-        console.log('hash has changed');
         $scope.parseHash();
     };
 

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -701,17 +701,17 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     $scope.parseHash = function() {
 
         //Fill in url parameters, they take precedence over the stored settings, but store them
-        var params = $location.$$hash.split('&').map(function(val) { return {key: val.split('=')[0], value: val.split('=')[1]}; });
-        var hostParam = params.find(function(p) { return p.key === 'host'; });
-        var portParam = params.find(function(p) { return p.key === 'port'; });
-        var pathParam = params.find(function(p) { return p.key === 'path'; });
-        var passwordParam = params.find(function(p) { return p.key === 'password'; });
-        var autoconnectParam = params.find(function(p) { return p.key === 'autoconnect'; });
-        if(hostParam) { $scope.settings.host = hostParam.value; $scope.settings.hostField = hostParam.value;}
-        if(portParam) { $scope.settings.port =  parseInt(portParam.value);}
-        if(pathParam) { $scope.settings.path = pathParam.value;}
-        if(passwordParam) { $scope.settings.password = passwordParam.value;}
-        if(autoconnectParam) { $scope.settings.autoconnect = autoconnectParam.value === 'true';}
+        var params = {};
+        $location.$$hash.split('&').map(function(val) {
+            var segs = val.split('=');
+            params[segs[0]] = segs[1];
+        });
+        if(params.host) { $scope.settings.host = params.host; $scope.settings.hostField = params.host; }
+        if(params.port) { $scope.settings.port =  parseInt(params.port); }
+        if(params.path) { $scope.settings.path = params.path; $scope.settings.hostField = $scope.settings.host + ":" + $scope.settings.port + "/" + $scope.settings.path; }
+        if(params.password) { $scope.password = params.password; }
+        if(params.autoconnect) { $scope.settings.autoconnect = params.autoconnect === 'true'; }
+
     };
 
     $scope.connect = function() {

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -23,8 +23,6 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     function ($rootScope, $scope, $store, $timeout, $location, $log, models, bufferResume, connection, notifications, utils, settings)
 {
 
-    $location.path(window.location.pathname);
-
     window.openBuffer = function(channel) {
         $scope.openBuffer(channel);
         $scope.$apply();

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -13,7 +13,10 @@ var weechat = angular.module('weechat', ['ngRoute', 'localStorage', 'weechatMode
     weechat.compileProvider = $compileProvider;
 
     //remove hashbang from url
-    $locationProvider.html5Mode(true).hashPrefix('');
+    $locationProvider.html5Mode({
+        enabled: true,
+        requireBase: false
+    }).hashPrefix('');
 }]);
 weechat.config(['$compileProvider', function ($compileProvider) {
     // hack to determine whether we're executing the tests


### PR DESCRIPTION
fixes #1005
This started out as just the issue fix but found it a weird way to do it so I tried to improve it. It now also no longer gives the atob error in the console.

- Remove /#! from the url this is foreign for most web stuff and confusing. Old URLs should keep working by redirecting to the /.
- Add url parameters
- Add documentation for the url paramters.