### PR TITLE
Encrypted connection by default, force unencrypted checkbox if allowed

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,9 +139,9 @@
                     </label>
                   </div>
                   <div class="checkbox">
-                    <label class="control-label" for="ssl">
-                      <input type="checkbox" id="ssl" ng-model="settings.ssl">
-                      Encryption. <strong>Strongly recommended!</strong> Need help? Check below.
+                    <label class="control-label" for="forceUnencrypted">
+                      <input type="checkbox" id="forceUnencrypted" ng-model="settings.forceUnencrypted" ng-disabled="!allowUnencrypted">
+                      Force unencrypted connection (not recommended)
                     </label>
                   </div>
                   <div class="checkbox" ng-show="settings.savepassword || settings.autoconnect">
@@ -184,6 +184,8 @@ chown -R <strong>username</strong>:<strong>username</strong> ~<strong>username</
 /relay add ssl.weechat {{ settings.port || 9001 }}
 </pre>
               <p>Your certificate needs to be renewed every couple of months. Either follow the instructions for automatic renewal at <a href="https://certbot.eff.org/">https://certbot.eff.org</a>, or run <code>certbot renew</code> manually when renewal is due. <strong>Important:</strong> You'll need to follow the instructions for copying the certificate to the right place again, and re-run <code>/relay sslcertkey</code> in WeeChat.</p>
+              <h4>Force unencrypted connections</h4>
+              By default connections are encrypted using TLS. The interface only allows unencrypted connections on local networks. The hostname must be: a local IPv4 address, a local IPv6 address, <code>localhost</code> or a tor hidden service (.onion).
               <h3>Use TOTP (Time-based One-Time Password)</h3>
               <p><a href="https://blog.weechat.org/post/2019/01/14/Support-of-TOTP">Configure</a> WeeChat for TOTP. The secret key has to be a base 32 string.</p>
               <pre>/secure set relay_totp_secret xxxxx
@@ -285,6 +287,7 @@ chown -R <strong>username</strong>:<strong>username</strong> ~<strong>username</
                     <li>path</li>
                     <li>password</li>
                     <li>autoconnect</li>
+                    <li>forceUnencrypted</li>
                   </ul>
                 </p>
             </div>

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -942,7 +942,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         // Support different browser quirks
         var code = $event.keyCode ? $event.keyCode : $event.charCode;
 
-        // Handle escapeforceUnencrypted
+        // Handle escape
         if (code === 27) {
             $event.preventDefault();
             $scope.search = '';


### PR DESCRIPTION
fixes #533 

Makes GB use SSL by default, 

- change the 'encrypted' checkbox to 'force unencrypted'
- disable this checkbox for anything excapt local networks 
  - local IPv4
  - local IPv6
  - "localhost"
  - onion hidden service
- add url parameter for this checkbox
- add a paragraph in "getting started" documentation