### PR TITLE
Add TikTok plugin

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -558,12 +558,14 @@ plugins.factory('userPlugins', function() {
      * Very similar to twitter
      */
     var tikTokPlugin = new UrlPlugin('TikTok', function(url) {
-        var regex = /^https?:\/\/(www\.)?tiktok\.com\/(.+)/i,
+        var regex = /^https?:\/\/(www\.)?tiktok\.com\/@(.+)\/video\/(.+)/i,
             match = url.match(regex);
 
         if (match) {
 
             return function() {
+                var element = this.getElement();
+                
                 fetch("https://www.tiktok.com/oembed?url=" + url)
                 .then(function(response) {
                     return response.json();
@@ -573,7 +575,6 @@ plugins.factory('userPlugins', function() {
                     var scriptIndex = data.html.indexOf("<script ");
                     var content = data.html.substr(0, scriptIndex);
 
-                    var element = this.getElement();
                     element.innerHTML = content;
 
                     // The script tag needs to be generated manually or the browser won't load it

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -564,30 +564,24 @@ plugins.factory('userPlugins', function() {
         if (match) {
 
             return function() {
+                fetch("https://www.tiktok.com/oembed?url=" + url)
+                .then(function(response) {
+                    return response.json();
+                    })
+                .then(function(data) {
+                    // separate the HTML into content and script tag
+                    var scriptIndex = data.html.indexOf("<script ");
+                    var content = data.html.substr(0, scriptIndex);
 
-                var element = this.getElement();
+                    var element = this.getElement();
+                    element.innerHTML = content;
 
-                GetEmbedContent( "https://www.tiktok.com/oembed?url=" + url, element);
-
-                function GetEmbedContent(embedurl, element) {
-                    fetch(embedurl)
-                    .then(function(response) {
-                        return response.json();
-                      })
-                    .then(function(data) {
-                        // separate the HTML into content and script tag
-                        var scriptIndex = data.html.indexOf("<script ");
-                        var content = data.html.substr(0, scriptIndex);
-    
-                        element.innerHTML = content;
-    
-                        // The script tag needs to be generated manually or the browser won't load it
-                        var scriptElem = document.createElement('script');
-                        // Hardcoding the URL here, I don't suppose it's going to change anytime soon
-                        scriptElem.src = "https://www.tiktok.com/embed.js";
-                        element.appendChild(scriptElem);
-                    });
-                }
+                    // The script tag needs to be generated manually or the browser won't load it
+                    var scriptElem = document.createElement('script');
+                    // Hardcoding the URL here, I don't suppose it's going to change anytime soon
+                    scriptElem.src = "https://www.tiktok.com/embed.js";
+                    element.appendChild(scriptElem);
+                });
             };
         }
     });

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -561,7 +561,7 @@ plugins.factory('userPlugins', function() {
         var regex = /^https?:\/\/(www\.)?tiktok\.com\/(.+)/i,
             match = url.match(regex);
 
-        if (match){
+        if (match) {
 
             return function() {
 
@@ -569,8 +569,7 @@ plugins.factory('userPlugins', function() {
 
                 GetEmbedContent( "https://www.tiktok.com/oembed?url=" + url, element);
 
-                function GetEmbedContent(embedurl, element)
-                {
+                function GetEmbedContent(embedurl, element) {
                     fetch(embedurl)
                     .then(function(response) {
                         return response.json();

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -553,8 +553,48 @@ plugins.factory('userPlugins', function() {
         }
     });
 
+    /*
+     * TikTok embedded player
+     * Very similar to twitter
+     */
+    var tikTokPlugin = new UrlPlugin('TikTok', function(url) {
+        var regex = /^https?:\/\/(www\.)?tiktok\.com\/(.+)/i,
+            match = url.match(regex);
+
+        if (match){
+
+            return function() {
+
+                var element = this.getElement();
+
+                GetEmbedContent( "https://www.tiktok.com/oembed?url=" + url, element);
+
+                function GetEmbedContent(embedurl, element)
+                {
+                    fetch(embedurl)
+                    .then(function(response) {
+                        return response.json();
+                      })
+                    .then(function(data) {
+                        // separate the HTML into content and script tag
+                        var scriptIndex = data.html.indexOf("<script ");
+                        var content = data.html.substr(0, scriptIndex);
+    
+                        element.innerHTML = content;
+    
+                        // The script tag needs to be generated manually or the browser won't load it
+                        var scriptElem = document.createElement('script');
+                        // Hardcoding the URL here, I don't suppose it's going to change anytime soon
+                        scriptElem.src = "https://www.tiktok.com/embed.js";
+                        element.appendChild(scriptElem);
+                    });
+                }
+            };
+        }
+    });
+
     return {
-        plugins: [youtubePlugin, dailymotionPlugin, allocinePlugin, imagePlugin, videoPlugin, audioPlugin, spotifyPlugin, cloudmusicPlugin, googlemapPlugin, asciinemaPlugin, yrPlugin, gistPlugin, pastebinPlugin, giphyPlugin, tweetPlugin, streamablePlugin]
+        plugins: [youtubePlugin, dailymotionPlugin, allocinePlugin, imagePlugin, videoPlugin, audioPlugin, spotifyPlugin, cloudmusicPlugin, googlemapPlugin, asciinemaPlugin, yrPlugin, gistPlugin, pastebinPlugin, giphyPlugin, tweetPlugin, streamablePlugin, tikTokPlugin]
     };
 
 

--- a/test/unit/plugins.js
+++ b/test/unit/plugins.js
@@ -169,5 +169,15 @@ describe('filter', function() {
             plugins);
         }));
 
+        it('should recognize tiktoks', inject(function(plugins) {
+            expectTheseMessagesToContain([
+                'https://www.tiktok.com/@scout2015/video/6718335390845095173',
+                'https://www.tiktok.com/@lewiscatpaldi/video/6800461190058298629',
+                'https://www.tiktok.com/@bhattrai_fam5_kavita/video/6811222914768047365',
+            ],
+            'TikTok',
+            plugins);
+        }));
+
     });
 });


### PR DESCRIPTION
Embeds tik tok links.. Is very similar to twitter. The embed is rather big but I don't see a simple way of changing it.

https://developers.tiktok.com/doc/Embed

example link: https://www.tiktok.com/@scout2015/video/6718335390845095173

Only those links are embedded. Tiktok also has shortened links in the format vm.tktok.com/xxxx. Those are impossible to embed in my experience due to CORS. They are a redirect to a normal link but it's not possible to get the redirect location in code due to CORS.