### PR TITLE
Prevent errors when scrolling non existant history

### DIFF
--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -477,7 +477,7 @@ weechat.directive('inputBar', function() {
                 // Arrow up -> go up in history
                 if ($event.type === "keydown" && code === 38 && document.activeElement === inputNode) {
                     caretPos = inputNode.selectionStart;
-                    if ($scope.command.slice(0, caretPos).indexOf("\n") !== -1) {
+                    if (!$scope.command || $scope.command.slice(0, caretPos).indexOf("\n") !== -1) {
                         return false;
                     }
                     $scope.command = models.getActiveBuffer().getHistoryUp($scope.command);
@@ -494,7 +494,7 @@ weechat.directive('inputBar', function() {
                 // Arrow down -> go down in history
                 if ($event.type === "keydown" && code === 40 && document.activeElement === inputNode) {
                     caretPos = inputNode.selectionStart;
-                    if ($scope.command.slice(caretPos).indexOf("\n") !== -1) {
+                    if (!$scope.command || $scope.command.slice(caretPos).indexOf("\n") !== -1) {
                         return false;
                     }
                     $scope.command = models.getActiveBuffer().getHistoryDown($scope.command);


### PR DESCRIPTION
If you go in the inputbar and press up and down you'd get errors if it was a brand new buffer that has no history.

angular.js:15536 TypeError: Cannot read property 'slice' of undefined
    at m.w.handleKeyPress (inputbar.js:497)
    at fn (eval at compile (angular.js:16387), <anonymous>:4:240)
    at e (angular.js:28815)
    at m.$eval (angular.js:19356)
    at m.$apply (angular.js:19455)
    at HTMLBodyElement.<anonymous> (angular.js:28819)
    at og (angular.js:3805)
    at HTMLBodyElement.d (angular.js:3793)