### PR TITLE
Hide bufferline times for relay buffers

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -960,3 +960,11 @@ code {
     color: #444;
     border: 1pt solid #444;
 }
+
+#bufferlines.hideTime td.time {
+    display:none;
+}
+
+#bufferlines.hideTime td.prefix {
+    display:none;
+}

--- a/index.html
+++ b/index.html
@@ -407,12 +407,12 @@ npm run build-electron-{windows, darwin, linux}</pre>
           </tbody>
           <tbody ng-repeat="bufferline in bufferlines">
             <tr class="bufferline">
-              <td class="time" ng-show="activeBuffer().showTime">
+              <td class="time" ng-show="activeBuffer().showBufferLineTimes">
                 <span class="date" ng-class="::{'repeated-time': bufferline.shortTime==bufferlines[$index-1].shortTime}">
                   <span class="cof-chat_time cob-chat_time coa-chat_time" ng-bind-html="::bufferline.formattedTime"></span>
                 </span>
               </td>
-              <td class="prefix" ng-show="activeBuffer().showTime"><span ng-class="::{'repeated-prefix': bufferline.prefixtext==bufferlines[$index-1].prefixtext}"><a ng-click="addMention(bufferline)"><span class="hidden-bracket" ng-if="::(bufferline.showHiddenBrackets)">&lt;</span><span ng-repeat="part in ::bufferline.prefix" ng-class="::part.classes" ng-bind="::part.text|prefixlimit:25"></span><span class="hidden-bracket" ng-if="::(bufferline.showHiddenBrackets)">&gt;</span></a></span></td><!--
+              <td class="prefix" ng-show="activeBuffer().showBufferLineTimes"><span ng-class="::{'repeated-prefix': bufferline.prefixtext==bufferlines[$index-1].prefixtext}"><a ng-click="addMention(bufferline)"><span class="hidden-bracket" ng-if="::(bufferline.showHiddenBrackets)">&lt;</span><span ng-repeat="part in ::bufferline.prefix" ng-class="::part.classes" ng-bind="::part.text|prefixlimit:25"></span><span class="hidden-bracket" ng-if="::(bufferline.showHiddenBrackets)">&gt;</span></a></span></td><!--
            --><td class="message"><!--
              --><div ng-repeat="metadata in ::bufferline.metadata" plugin data="::metadata"></div><!--
              --><span ng-repeat="part in ::bufferline.content" class="text" ng-class="::part.classes.concat(['line-' + part.$$hashKey.replace(':','_')])" ng-bind-html="::part.text | conditionalLinkify:part.classes.includes('cof-chat_host') | DOMfilter:'codify' | DOMfilter:'irclinky' | DOMfilter:'emojify':settings.enableJSEmoji | DOMfilter:'inlinecolour' |  DOMfilter:'latexmath':('.line-' + part.$$hashKey.replace(':','_')):settings.enableMathjax"></span>

--- a/index.html
+++ b/index.html
@@ -395,7 +395,7 @@ npm run build-electron-{windows, darwin, linux}</pre>
           </li>
         </ul>
       </div>
-      <div id="bufferlines" class="favorite-font" ng-swipe-right="swipeRight()" ng-swipe-left="swipeLeft()" ng-swipe-disable-mouse ng-class="{'withnicklist': showNicklist, 'hideTime': !activeBuffer().showBufferLineTimes}" when-scrolled="infiniteScroll()" imgur-drop>
+      <div id="bufferlines" class="favorite-font" ng-swipe-right="swipeRight()" ng-swipe-left="swipeLeft()" ng-swipe-disable-mouse ng-class="{'withnicklist': showNicklist, 'hideTime': activeBuffer().hideBufferLineTimes}" when-scrolled="infiniteScroll()" imgur-drop>
         <table>
           <tbody>
             <tr class="bufferline">

--- a/index.html
+++ b/index.html
@@ -407,12 +407,12 @@ npm run build-electron-{windows, darwin, linux}</pre>
           </tbody>
           <tbody ng-repeat="bufferline in bufferlines">
             <tr class="bufferline">
-              <td class="time">
+              <td class="time" ng-show="activeBuffer().showTime">
                 <span class="date" ng-class="::{'repeated-time': bufferline.shortTime==bufferlines[$index-1].shortTime}">
                   <span class="cof-chat_time cob-chat_time coa-chat_time" ng-bind-html="::bufferline.formattedTime"></span>
                 </span>
               </td>
-              <td class="prefix"><span ng-class="::{'repeated-prefix': bufferline.prefixtext==bufferlines[$index-1].prefixtext}"><a ng-click="addMention(bufferline)"><span class="hidden-bracket" ng-if="::(bufferline.showHiddenBrackets)">&lt;</span><span ng-repeat="part in ::bufferline.prefix" ng-class="::part.classes" ng-bind="::part.text|prefixlimit:25"></span><span class="hidden-bracket" ng-if="::(bufferline.showHiddenBrackets)">&gt;</span></a></span></td><!--
+              <td class="prefix" ng-show="activeBuffer().showTime"><span ng-class="::{'repeated-prefix': bufferline.prefixtext==bufferlines[$index-1].prefixtext}"><a ng-click="addMention(bufferline)"><span class="hidden-bracket" ng-if="::(bufferline.showHiddenBrackets)">&lt;</span><span ng-repeat="part in ::bufferline.prefix" ng-class="::part.classes" ng-bind="::part.text|prefixlimit:25"></span><span class="hidden-bracket" ng-if="::(bufferline.showHiddenBrackets)">&gt;</span></a></span></td><!--
            --><td class="message"><!--
              --><div ng-repeat="metadata in ::bufferline.metadata" plugin data="::metadata"></div><!--
              --><span ng-repeat="part in ::bufferline.content" class="text" ng-class="::part.classes.concat(['line-' + part.$$hashKey.replace(':','_')])" ng-bind-html="::part.text | conditionalLinkify:part.classes.includes('cof-chat_host') | DOMfilter:'codify' | DOMfilter:'irclinky' | DOMfilter:'emojify':settings.enableJSEmoji | DOMfilter:'inlinecolour' |  DOMfilter:'latexmath':('.line-' + part.$$hashKey.replace(':','_')):settings.enableMathjax"></span>

--- a/index.html
+++ b/index.html
@@ -395,7 +395,7 @@ npm run build-electron-{windows, darwin, linux}</pre>
           </li>
         </ul>
       </div>
-      <div id="bufferlines" class="favorite-font" ng-swipe-right="swipeRight()" ng-swipe-left="swipeLeft()" ng-swipe-disable-mouse ng-class="{'withnicklist': showNicklist}" when-scrolled="infiniteScroll()" imgur-drop>
+      <div id="bufferlines" class="favorite-font" ng-swipe-right="swipeRight()" ng-swipe-left="swipeLeft()" ng-swipe-disable-mouse ng-class="{'withnicklist': showNicklist, 'hideTime': !activeBuffer().showBufferLineTimes}" when-scrolled="infiniteScroll()" imgur-drop>
         <table>
           <tbody>
             <tr class="bufferline">
@@ -407,12 +407,12 @@ npm run build-electron-{windows, darwin, linux}</pre>
           </tbody>
           <tbody ng-repeat="bufferline in bufferlines">
             <tr class="bufferline">
-              <td class="time" ng-show="activeBuffer().showBufferLineTimes">
+              <td class="time">
                 <span class="date" ng-class="::{'repeated-time': bufferline.shortTime==bufferlines[$index-1].shortTime}">
                   <span class="cof-chat_time cob-chat_time coa-chat_time" ng-bind-html="::bufferline.formattedTime"></span>
                 </span>
               </td>
-              <td class="prefix" ng-show="activeBuffer().showBufferLineTimes"><span ng-class="::{'repeated-prefix': bufferline.prefixtext==bufferlines[$index-1].prefixtext}"><a ng-click="addMention(bufferline)"><span class="hidden-bracket" ng-if="::(bufferline.showHiddenBrackets)">&lt;</span><span ng-repeat="part in ::bufferline.prefix" ng-class="::part.classes" ng-bind="::part.text|prefixlimit:25"></span><span class="hidden-bracket" ng-if="::(bufferline.showHiddenBrackets)">&gt;</span></a></span></td><!--
+              <td class="prefix"><span ng-class="::{'repeated-prefix': bufferline.prefixtext==bufferlines[$index-1].prefixtext}"><a ng-click="addMention(bufferline)"><span class="hidden-bracket" ng-if="::(bufferline.showHiddenBrackets)">&lt;</span><span ng-repeat="part in ::bufferline.prefix" ng-class="::part.classes" ng-bind="::part.text|prefixlimit:25"></span><span class="hidden-bracket" ng-if="::(bufferline.showHiddenBrackets)">&gt;</span></a></span></td><!--
            --><td class="message"><!--
              --><div ng-repeat="metadata in ::bufferline.metadata" plugin data="::metadata"></div><!--
              --><span ng-repeat="part in ::bufferline.content" class="text" ng-class="::part.classes.concat(['line-' + part.$$hashKey.replace(':','_')])" ng-bind-html="::part.text | conditionalLinkify:part.classes.includes('cof-chat_host') | DOMfilter:'codify' | DOMfilter:'irclinky' | DOMfilter:'emojify':settings.enableJSEmoji | DOMfilter:'inlinecolour' |  DOMfilter:'latexmath':('.line-' + part.$$hashKey.replace(':','_')):settings.enableMathjax"></span>

--- a/js/models.js
+++ b/js/models.js
@@ -92,11 +92,7 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
         var bufferType = message.type;
 
         // If type is undefined set it as other to avoid later errors
-        var type = message.local_variables.type;
-        if (!type) {
-            type = 'other';
-        }
-
+        var type = message.local_variables.type || 'other';
         var indent = (['channel', 'private'].indexOf(type) >= 0);
 
         var plugin = message.local_variables.plugin;
@@ -104,8 +100,8 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
 
         var pinned = message.local_variables.pinned === "true";
 
-        //hide timestamps for certain buffer types
-        var showBufferLineTimes = type && type !== 'relay';
+        // hide timestamps for certain buffer types
+        var hideBufferLineTimes = type && type === 'relay';
 
         // Server buffers have this "irc.server.freenode" naming schema, which
         // messes the sorting up. We need it to be "irc.freenode" instead.
@@ -374,7 +370,7 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
             getHistoryDown: getHistoryDown,
             isNicklistEmpty: isNicklistEmpty,
             nicklistRequested: nicklistRequested,
-            showBufferLineTimes: showBufferLineTimes,
+            hideBufferLineTimes: hideBufferLineTimes,
             pinned: pinned,
             queryNicklist: queryNicklist,
         };

--- a/js/models.js
+++ b/js/models.js
@@ -90,7 +90,7 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
         // There are two kinds of types: bufferType (free vs formatted) and
         // the kind of type that distinguishes queries from channels etc
         var bufferType = message.type;
-        
+
         // If type is undefined set it as other to avoid later errors
         var type = message.local_variables.type;
         if (!type) {
@@ -105,7 +105,7 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
         var pinned = message.local_variables.pinned === "true";
 
         //hide timestamps for certain buffer types
-        var showTime = type && type !== 'relay';
+        var showBufferLineTimes = type && type !== 'relay';
 
         // Server buffers have this "irc.server.freenode" naming schema, which
         // messes the sorting up. We need it to be "irc.freenode" instead.
@@ -374,7 +374,7 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
             getHistoryDown: getHistoryDown,
             isNicklistEmpty: isNicklistEmpty,
             nicklistRequested: nicklistRequested,
-            showTime: showTime,
+            showBufferLineTimes: showBufferLineTimes,
             pinned: pinned,
             queryNicklist: queryNicklist,
         };

--- a/js/models.js
+++ b/js/models.js
@@ -98,6 +98,9 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
 
         var pinned = message.local_variables.pinned === "true";
 
+        //hide timestamps for certain buffer types
+        var showTime = type && type !== 'relay';
+
         // Server buffers have this "irc.server.freenode" naming schema, which
         // messes the sorting up. We need it to be "irc.freenode" instead.
         var serverSortKey = plugin + "." + server +
@@ -365,6 +368,7 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
             getHistoryDown: getHistoryDown,
             isNicklistEmpty: isNicklistEmpty,
             nicklistRequested: nicklistRequested,
+            showTime: showTime,
             pinned: pinned,
             queryNicklist: queryNicklist,
         };

--- a/js/models.js
+++ b/js/models.js
@@ -90,7 +90,13 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
         // There are two kinds of types: bufferType (free vs formatted) and
         // the kind of type that distinguishes queries from channels etc
         var bufferType = message.type;
+        
+        // If type is undefined set it as other to avoid later errors
         var type = message.local_variables.type;
+        if (!type) {
+            type = 'other';
+        }
+
         var indent = (['channel', 'private'].indexOf(type) >= 0);
 
         var plugin = message.local_variables.plugin;


### PR DESCRIPTION
For certain buffers a timestamp does not make sense and is always 00:00:00. This is the case for the buffertype 'relay'. This hides the timestamps for these buffers.

![TElyS4YsF1](https://user-images.githubusercontent.com/23409814/79073598-c6092880-7ce7-11ea-9540-b39a69b50e4c.png)
