### PR TITLE
Show correct error message when giving wrong password in firefox

### DIFF
--- a/js/connection.js
+++ b/js/connection.js
@@ -33,7 +33,6 @@ weechat.factory('connection',
 
         var onopen = function () {
 
-
             // Helper methods for initialization commands
             var _initializeConnection = function(passwd) {
                 // Escape comma in password (#937)
@@ -204,51 +203,51 @@ weechat.factory('connection',
             _initializeConnection(passwd).then(
                 function() {
                     _requestVersion().then(
-                        function(version) {
-                            handlers.handleVersionInfo(version);
-                            // Connection is successful
-                            // Send all the other commands required for initialization
-                            _requestBufferInfos().then(function(bufinfo) {
-                                handlers.handleBufferInfo(bufinfo);
-                            });
-        
-                            _requestHotlist().then(function(hotlist) {
-                                handlers.handleHotlistInfo(hotlist);
-        
-                            });
-                            if (settings.hotlistsync) {
-                                // Schedule hotlist syncing every so often so that this
-                                // client will have unread counts (mostly) in sync with
-                                // other clients or terminal usage directly.
-                                setInterval(function() {
-                                    if ($rootScope.connected) {
-                                        _requestHotlist().then(function(hotlist) {
-                                            handlers.handleHotlistInfo(hotlist);
-        
-                                        });
-                                    }
-                                }, 60000); // Sync hotlist every 60 second
-                            }
-        
-        
-                            // Fetch weechat time format for displaying timestamps
-                            fetchConfValue('weechat.look.buffer_time_format',
-                                           function() {
-                                               // Will set models.wconfig['weechat.look.buffer_time_format']
-                                               _parseWeechatTimeFormat();
-                            });
-        
-                            // Fetch nick completion config
-                            fetchConfValue('weechat.completion.nick_completer');
-                            fetchConfValue('weechat.completion.nick_add_space');
-        
-                            _requestSync();
-                            $log.info("Connected to relay");
-                            $rootScope.connected = true;
-                            if (successCallback) {
-                                successCallback();
-                            }
+                    function(version) {
+                        handlers.handleVersionInfo(version);
+                        // Connection is successful
+                        // Send all the other commands required for initialization
+                        _requestBufferInfos().then(function(bufinfo) {
+                            handlers.handleBufferInfo(bufinfo);
                         });
+    
+                        _requestHotlist().then(function(hotlist) {
+                            handlers.handleHotlistInfo(hotlist);
+    
+                        });
+                        if (settings.hotlistsync) {
+                            // Schedule hotlist syncing every so often so that this
+                            // client will have unread counts (mostly) in sync with
+                            // other clients or terminal usage directly.
+                            setInterval(function() {
+                                if ($rootScope.connected) {
+                                    _requestHotlist().then(function(hotlist) {
+                                        handlers.handleHotlistInfo(hotlist);
+    
+                                    });
+                                }
+                            }, 60000); // Sync hotlist every 60 second
+                        }
+    
+    
+                        // Fetch weechat time format for displaying timestamps
+                        fetchConfValue('weechat.look.buffer_time_format',
+                                        function() {
+                                            // Will set models.wconfig['weechat.look.buffer_time_format']
+                                            _parseWeechatTimeFormat();
+                        });
+    
+                        // Fetch nick completion config
+                        fetchConfValue('weechat.completion.nick_completer');
+                        fetchConfValue('weechat.completion.nick_add_space');
+    
+                        _requestSync();
+                        $log.info("Connected to relay");
+                        $rootScope.connected = true;
+                        if (successCallback) {
+                            successCallback();
+                        }
+                    });
                 }
             , function() {
                 handleWrongPassword();

--- a/js/connection.js
+++ b/js/connection.js
@@ -202,52 +202,52 @@ weechat.factory('connection',
             // did not provide the proper password.
             _initializeConnection(passwd).then(
                 function() {
-                    _requestVersion().then(
-                    function(version) {
-                        handlers.handleVersionInfo(version);
-                        // Connection is successful
-                        // Send all the other commands required for initialization
-                        _requestBufferInfos().then(function(bufinfo) {
-                            handlers.handleBufferInfo(bufinfo);
-                        });
-    
-                        _requestHotlist().then(function(hotlist) {
-                            handlers.handleHotlistInfo(hotlist);
-    
-                        });
-                        if (settings.hotlistsync) {
-                            // Schedule hotlist syncing every so often so that this
-                            // client will have unread counts (mostly) in sync with
-                            // other clients or terminal usage directly.
-                            setInterval(function() {
-                                if ($rootScope.connected) {
-                                    _requestHotlist().then(function(hotlist) {
-                                        handlers.handleHotlistInfo(hotlist);
-    
-                                    });
-                                }
-                            }, 60000); // Sync hotlist every 60 second
-                        }
-    
-    
-                        // Fetch weechat time format for displaying timestamps
-                        fetchConfValue('weechat.look.buffer_time_format',
-                                        function() {
-                                            // Will set models.wconfig['weechat.look.buffer_time_format']
-                                            _parseWeechatTimeFormat();
-                        });
-    
-                        // Fetch nick completion config
-                        fetchConfValue('weechat.completion.nick_completer');
-                        fetchConfValue('weechat.completion.nick_add_space');
-    
-                        _requestSync();
-                        $log.info("Connected to relay");
-                        $rootScope.connected = true;
-                        if (successCallback) {
-                            successCallback();
-                        }
+                _requestVersion().then(
+                function(version) {
+                    handlers.handleVersionInfo(version);
+                    // Connection is successful
+                    // Send all the other commands required for initialization
+                    _requestBufferInfos().then(function(bufinfo) {
+                        handlers.handleBufferInfo(bufinfo);
                     });
+
+                    _requestHotlist().then(function(hotlist) {
+                        handlers.handleHotlistInfo(hotlist);
+
+                    });
+                    if (settings.hotlistsync) {
+                        // Schedule hotlist syncing every so often so that this
+                        // client will have unread counts (mostly) in sync with
+                        // other clients or terminal usage directly.
+                        setInterval(function() {
+                            if ($rootScope.connected) {
+                                _requestHotlist().then(function(hotlist) {
+                                    handlers.handleHotlistInfo(hotlist);
+
+                                });
+                            }
+                        }, 60000); // Sync hotlist every 60 second
+                    }
+
+
+                    // Fetch weechat time format for displaying timestamps
+                    fetchConfValue('weechat.look.buffer_time_format',
+                                    function() {
+                                        // Will set models.wconfig['weechat.look.buffer_time_format']
+                                        _parseWeechatTimeFormat();
+                    });
+
+                    // Fetch nick completion config
+                    fetchConfValue('weechat.completion.nick_completer');
+                    fetchConfValue('weechat.completion.nick_add_space');
+
+                    _requestSync();
+                    $log.info("Connected to relay");
+                    $rootScope.connected = true;
+                    if (successCallback) {
+                        successCallback();
+                    }
+                });
                 }
             , function() {
                 handleWrongPassword();

--- a/js/websockets.js
+++ b/js/websockets.js
@@ -138,12 +138,17 @@ function($rootScope, $q) {
         ws.close();
     };
 
+    var readyState = function() {
+        return ws.readyState;
+    }
+
     return {
         send: send,
         sendAll: sendAll,
         connect: connect,
         disconnect: disconnect,
-        failCallbacks: failCallbacks
+        failCallbacks: failCallbacks,
+        readyState: readyState
     };
 
 }]);


### PR DESCRIPTION
fixes #1116 
Change the way we initialize, after sending the init message, give it 100ms for weechat to check the password and see if weechat closed the connection or not. If after 100ms the connection is still open we proceed to send the info version command.

What the problem is with sending info version instantly is that chrome handles it differently than firefox. Chrome has already sent the info version before the connection is closed. While firefox send it right after the connection is closed and generates an error. This error is assumed to be a certificate error so the wrong error message is shown to the user.

The indents might not be correct around connection.js ln 206 but that is for clarity of the changes.

Checks I make:
- firefox gives right error when password is wrong
- chrome gives right error when password is wrong
- firefox gives right error when certificate is wrong
- chrome gives right error when certificate is wrong