### PR TITLE
Command completion for weechat 2.9

### DIFF
--- a/js/connection.js
+++ b/js/connection.js
@@ -528,6 +528,25 @@ weechat.factory('connection',
         });
     };
 
+    var requestCompletion = function(bufferId, position, data) {
+        // Prevent requesting completion if bufferId is invalid
+        if (!bufferId) {
+            return;
+        }
+
+        return ngWebsockets.send(
+            weeChat.Protocol.formatCompletion({
+                buffer: "0x" + bufferId,
+                position: position,
+                data: data
+            })
+        ).then(function(message) {
+            return new Promise(function (resolve) {
+                resolve( handlers.handleCompletion(message) );
+            });
+        });
+    };
+
 
     return {
         connect: connect,
@@ -538,7 +557,8 @@ weechat.factory('connection',
         sendHotlistClearAll: sendHotlistClearAll,
         fetchMoreLines: fetchMoreLines,
         requestNicklist: requestNicklist,
-        attemptReconnect: attemptReconnect
+        attemptReconnect: attemptReconnect,
+        requestCompletion: requestCompletion
     };
 }]);
 })();

--- a/js/handlers.js
+++ b/js/handlers.js
@@ -491,6 +491,12 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
         });
     };
 
+    var handleCompletion = function(message) {
+        var completionInfo = message.objects[0].content[0];
+
+        return completionInfo;
+    };
+
     var eventHandlers = {
         _buffer_closing: handleBufferClosing,
         _buffer_line_added: handleBufferLineAdded,
@@ -529,7 +535,8 @@ weechat.factory('handlers', ['$rootScope', '$log', 'models', 'plugins', 'notific
         handleLineInfo: handleLineInfo,
         handleHotlistInfo: handleHotlistInfo,
         handleNicklist: handleNicklist,
-        handleBufferInfo: handleBufferInfo
+        handleBufferInfo: handleBufferInfo,
+        handleCompletion: handleCompletion
     };
 
 }]);

--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -472,7 +472,7 @@ weechat.directive('inputBar', function() {
                     return true;
                 }
 
-                // Tab -> nick completion
+                // Shitft-Tab -> nick completion backward (only commands)
                 if (code === 9 && !$event.altKey && !$event.ctrlKey && $event.shiftKey) {
                     $event.preventDefault();
                     $scope.completeCommand('backward');

--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -79,8 +79,10 @@ weechat.directive('inputBar', function() {
             };
 
             $scope.completeNick = function() {
-                if ( $scope.command.startsWith('/') ) {
-                    // We are completing a command, an other function will do this
+                if ((models.version[0] == 2 && models.version[1] >= 9 || models.version[0] > 2) &&
+                    $scope.command.startsWith('/') ) {
+                    // We are completing a command, another function will do
+                    // this on WeeChat 2.9 and later
                     return;
                 }
 
@@ -124,6 +126,11 @@ weechat.directive('inputBar', function() {
             var commandCompletionPositionInList;
             var commandCompletionInputChanged;
             $scope.completeCommand = function(direction) {
+                if (models.version[0] < 2 || (models.version[0] == 2 && models.version[1] < 9)) {
+                    // Command completion is only supported on WeeChat 2.9+
+                    return;
+                }
+
                 if ( !$scope.command.startsWith('/') ) {
                     // We are not completing a command, maybe a nick?
                     return;

--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -711,6 +711,7 @@ weechat.directive('inputBar', function() {
             $scope.handleCompleteNickButton = function($event) {
                 $event.preventDefault();
                 $scope.completeNick();
+                $scope.completeCommand('forward');
 
                 setTimeout(function() {
                     $scope.getInputNode().focus();

--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -189,6 +189,11 @@ weechat.directive('inputBar', function() {
                         inputNode.setSelectionRange(newCursorPos, newCursorPos);
                     }, 0);
 
+                    // If there is only one item in the list, we are done, no next cycle
+                    if ( commandCompletionList.length === 1) {
+                        previousInput = '';
+                        return;
+                    }
                     // Setup for the next cycle
                     commandCompletionPositionInList++;
                     commandCompletionBaseWord = replacedWord + suffix;

--- a/js/weechat.js
+++ b/js/weechat.js
@@ -778,6 +778,33 @@
     };
 
     /**
+     * Formats a completion command.
+     * https://weechat.org/files/doc/stable/weechat_relay_protocol.en.html#command_completion
+     * @param params Parameters:
+     *            id: command ID (optional)
+     *            buffer: target buffer (mandatory)
+     *            position: position for completion in string (optional)
+     *            data: input data (optional)
+     * @return Formatted input command string
+     */
+    WeeChatProtocol.formatCompletion = function(params) {
+        var defaultParams = {
+            id: null,
+            position: -1
+        };
+        var parts = [];
+
+        params = WeeChatProtocol._mergeParams(defaultParams, params);
+        parts.push(params.buffer);
+        parts.push(params.position);
+        if (params.data) {
+            parts.push(params.data);
+        }
+
+        return WeeChatProtocol._formatCmd(params.id, 'completion', parts);
+    };
+
+    /**
      * Formats a sync or a desync command.
      *
      * @param params Parameters (see _formatSync and _formatDesync)


### PR DESCRIPTION
A new command was introduced in 2.9 dev to be able to do completions of nicks and commands. Only implemented commands. https://weechat.org/files/doc/devel/weechat_relay_protocol.en.html#command_completion

- Don't do the old nick completion if line starts with /
- If line starts with / do command completion
  - Completes commands "/h" -> "/help, /halfop, ..."
  - Completes command arguments "/help " -> "/help -list, ..."
  - Cycle forwards with tab or the mobile button
  - Cycle backwards with shift-tab

fixes #1120
fixes #372 
