### PR TITLE
Show toast with deletion link for imgur uploads

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -704,7 +704,14 @@ li.buffer.indent.private a {
   border-radius: 3px;
   padding: 10px 15px;
   z-index: 100;
-  animation: fadein 0.5s, fadeout 0.5s 4.5s;
+}
+
+.toast-short {
+    animation: fadein 0.5s, fadeout 0.5s 4.5s;
+}
+
+.toast-long {
+    animation: fadein 0.5s, fadeout 0.5s 14.5s;
 }
 
 @keyframes fadein {

--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -708,7 +708,7 @@ img.emojione {
     width: auto;
 }
 
-#toast {
+.toast {
   position: fixed;
   left: 50%;
   bottom: 50px;

--- a/css/themes/base16-default.css
+++ b/css/themes/base16-default.css
@@ -423,7 +423,7 @@ button.close:hover {
     color: var(--base01);
 }
 
-#toast {
+.toast {
     background-color: var(--base01);
 }
 

--- a/css/themes/blue.css
+++ b/css/themes/blue.css
@@ -134,7 +134,7 @@ input[type=text], input[type=password], #sendMessage, .badge, .btn-send, .btn-se
    border: 1px solid #363943;
 }
 
-#toast {
+.toast {
     background-color: #283244;
     border: 1px solid;
     border-color: rgb(29, 94, 152);

--- a/css/themes/dark.css
+++ b/css/themes/dark.css
@@ -2126,7 +2126,7 @@ code {
   color: #fff;
 }
 
-#toast {
+.toast {
     background-color: #333;
 }
 

--- a/css/themes/light.css
+++ b/css/themes/light.css
@@ -2092,7 +2092,7 @@ input[type=text].is-invalid{
     font-weight: bold;
 }
 
-#toast {
+.toast {
     background-color: #ddd;
 }
 

--- a/js/imgur.js
+++ b/js/imgur.js
@@ -104,10 +104,8 @@ weechat.factory('imgur', ['$rootScope', 'settings', function($rootScope, setting
         };
 
         if( "upload" in xhttp ) {
-
             // Set progress
             xhttp.upload.onprogress = function (event) {
-
                 // Check if we can compute progress
                 if (event.lengthComputable) {
                     // Complete in percent
@@ -117,12 +115,9 @@ weechat.factory('imgur', ['$rootScope', 'settings', function($rootScope, setting
                     currentProgressBar.style.width = complete + '%';
                 }
             };
-
         }
-
         // Send request with form data
         xhttp.send(fd);
-
     };
 
     // Delete an image from imgur with the deletion link
@@ -156,22 +151,16 @@ weechat.factory('imgur', ['$rootScope', 'settings', function($rootScope, setting
 
         // Handler for response
         xhttp.onload = function() {
-
             // Check state and response status
             if(xhttp.status === 200) {
-
                 callback();
-
             } else {
                 showErrorMsg();
             }
-
         };
-
-
+        
         // Send request with form data
         xhttp.send(null);
-
     };
 
     var showErrorMsg = function() {

--- a/js/imgur.js
+++ b/js/imgur.js
@@ -140,11 +140,6 @@ weechat.factory('imgur', ['$rootScope', 'settings', function($rootScope, setting
             isClientID = false;
         }
 
-        // Add the image to the provided album if configured to do so
-        if (!isClientID && settings.iAlb.length >= 6) {
-            fd.append("album", settings.iAlb);
-        }
-
         // Create new XMLHttpRequest
         var xhttp = new XMLHttpRequest();
 

--- a/js/imgur.js
+++ b/js/imgur.js
@@ -153,7 +153,7 @@ weechat.factory('imgur', ['$rootScope', 'settings', function($rootScope, setting
         xhttp.onload = function() {
             // Check state and response status
             if(xhttp.status === 200) {
-                callback();
+                callback(deletehash);
             } else {
                 showErrorMsg();
             }

--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -280,12 +280,20 @@ weechat.directive('inputBar', function() {
                 }
             };
 
-            var deleteCallback = function () {
+            var deleteCallback = function (deleteHash) {
                 // Image got sucessfully deleted.
                 // Show toast with delete link
                 var toastDeleted = $compile('<div class="toast toast-short">Successfully deleted.</div>')($scope)[0];
                 document.body.appendChild(toastDeleted);
                 setTimeout(function() { document.body.removeChild(toastDeleted); }, 5000);
+
+                // Try to remove the toast with the deletion link (it stays 15s
+                // instead of the 5 of the deletion notification, so it could
+                // come back beneath it, which would be confusing)
+                var pasteToast = document.querySelector("[data-imgur-deletehash='" + deleteHash + "']");
+                if (!!pasteToast) {
+                    document.body.removeChild(pasteToast);
+                }
             }
 
             $scope.imgurDelete = function (deleteHash) {
@@ -774,7 +782,7 @@ weechat.directive('inputBar', function() {
                         }
 
                         // Show toast with delete link
-                        var toastImgur = $compile('<div class="toast toast-long">Image uploaded to Imgur. <a id="deleteImgur" ng-click="imgurDelete(\'' + deleteHash + '\')" href="">Delete?</a></div>')($scope)[0];
+                        var toastImgur = $compile('<div class="toast toast-long" data-imgur-deletehash=\'' + deleteHash + '\'>Image uploaded to Imgur. <a id="deleteImgur" ng-click="imgurDelete(\'' + deleteHash + '\')" href="">Delete?</a></div>')($scope)[0];
                         document.body.appendChild(toastImgur);
                         setTimeout(function() { document.body.removeChild(toastImgur); }, 15000);
 

--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -283,7 +283,7 @@ weechat.directive('inputBar', function() {
             var deleteCallback = function () {
                 // Image got sucessfully deleted.
                 // Show toast with delete link
-                var toastDeleted = $compile('<div class="toast">Successfully deleted.')($scope)[0];
+                var toastDeleted = $compile('<div class="toast">Successfully deleted.</div>')($scope)[0];
                 document.body.appendChild(toastDeleted);
                 setTimeout(function() { document.body.removeChild(toastDeleted); }, 5000);
             }

--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -776,7 +776,7 @@ weechat.directive('inputBar', function() {
                         // Show toast with delete link
                         var toastImgur = $compile('<div class="toast">Image uploaded to Imgur. <a id="deleteImgur" ng-click="imgurDelete(\'' + deleteHash + '\')" href="">Delete?</a></div>')($scope)[0];
                         document.body.appendChild(toastImgur);
-                        setTimeout(function() { document.body.removeChild(toastImgur); }, 5000);
+                        setTimeout(function() { document.body.removeChild(toastImgur); }, 10000);
 
                         // Log the delete hash to the console in case the toast was missed.
                         console.log('An image was uploaded to imgur, delete it with $scope.imgurDelete(\'' + deleteHash + '\')');

--- a/js/inputbar.js
+++ b/js/inputbar.js
@@ -283,7 +283,7 @@ weechat.directive('inputBar', function() {
             var deleteCallback = function () {
                 // Image got sucessfully deleted.
                 // Show toast with delete link
-                var toastDeleted = $compile('<div class="toast">Successfully deleted.</div>')($scope)[0];
+                var toastDeleted = $compile('<div class="toast toast-short">Successfully deleted.</div>')($scope)[0];
                 document.body.appendChild(toastDeleted);
                 setTimeout(function() { document.body.removeChild(toastDeleted); }, 5000);
             }
@@ -363,7 +363,7 @@ weechat.directive('inputBar', function() {
                 if (buffer.type === 'channel' && !is_online) {
                     // show a toast that the user left
                     var toast = document.createElement('div');
-                    toast.className = "toast";
+                    toast.className = "toast toast-short";
                     toast.innerHTML = nick + " has left the room";
                     document.body.appendChild(toast);
                     setTimeout(function() { document.body.removeChild(toast); }, 5000);
@@ -774,9 +774,9 @@ weechat.directive('inputBar', function() {
                         }
 
                         // Show toast with delete link
-                        var toastImgur = $compile('<div class="toast">Image uploaded to Imgur. <a id="deleteImgur" ng-click="imgurDelete(\'' + deleteHash + '\')" href="">Delete?</a></div>')($scope)[0];
+                        var toastImgur = $compile('<div class="toast toast-long">Image uploaded to Imgur. <a id="deleteImgur" ng-click="imgurDelete(\'' + deleteHash + '\')" href="">Delete?</a></div>')($scope)[0];
                         document.body.appendChild(toastImgur);
-                        setTimeout(function() { document.body.removeChild(toastImgur); }, 10000);
+                        setTimeout(function() { document.body.removeChild(toastImgur); }, 15000);
 
                         // Log the delete hash to the console in case the toast was missed.
                         console.log('An image was uploaded to imgur, delete it with $scope.imgurDelete(\'' + deleteHash + '\')');


### PR DESCRIPTION
After uploading an image through pasting an image in, a toast is shown with a deletion link. On clicking the link the image is deleted. The hash is also shown in the log.
Changed the #toast css to .toast because it's used in multiple divs and they need unique id.

Things I'm not sure about:
- Would this qualify to fix #1050
- This doesn't cover uploading with the button, but that cannot be done accidental. Reason I don't do this is because this uploads multiple images, not sure how the deletion would work, etc.
- The thing I print in the console cannot be execute if not on a suitable breakpoint. Not sure how to do this better. Also I cannot just show a link because it's a DELETE call, not a GET. Is there some page I can link to on imgur that has the deletion link?
