### PR TITLE
Add link to make it easier to create an exception for self signed certificates

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
         <strong>Connection error</strong> The client was unable to connect to the WeeChat relay
       </div>
       <div class="alert alert-danger" ng-show="sslError" ng-cloak>
-        <strong>Secure connection error</strong> A secure connection with the WeeChat relay could not be initiated. This is most likely because your browser does not trust your relay's certificate. Please read the encryption instructions below!
+        <strong>Secure connection error</strong> A secure connection with the WeeChat relay could not be initiated. This is most likely because your browser does not trust your relay's certificate. Please read the encryption instructions below! To add an exception go to <a href="https://{{ settings.hostField }}:{{ settings.port }}/">https://{{ settings.hostField }}:{{ settings.port }}/</a>.
       </div>
       <div class="alert alert-danger" ng-show="securityError" ng-cloak>
         <strong>Secure connection error</strong> Unable to connect to unencrypted relay when you are connecting to Glowing Bear over HTTPS. Please use an encrypted relay or load the page without using HTTPS.


### PR DESCRIPTION
If you want to use a self signed certificate you have to add an exception to be able to use it. To do this you have to visit the websoket location directly. Because browsers won't ask to add exceptions for 'subresources'. To make this accessible this PR adds a link in the warning to do this directly.

https://bugzilla.mozilla.org/show_bug.cgi?id=1187666