### PR TITLE
Use linkifyjs instead of linky

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,8 @@
     "angular-touch": "1.8.x",
     "angular-loader": "1.8.x",
     "angular-mocks": "1.8.x",
-    "underscore": "~1.10"
+    "underscore": "~1.10",
+    "linkifyjs": "jQuery-linkify#^2.1.9"
   },
   "devDependencies": {
     "bootstrap": "~3.4",

--- a/index.html
+++ b/index.html
@@ -25,6 +25,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-touch/1.8.0/angular-touch.min.js" integrity="sha512-Fv9vdYa1UF171Mgs1hGeRXULvHflaw78t5EPI/cG6pVp9SjhjlhfL2ifdkwxEP0EBAhlA02UuE8mEjm65CYYpw==" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.10.2/underscore-min.js" integrity="sha512-HKvDCFVKg8ZPGjecy6on7UECEpE76Y86h3GaE4JMCz+deFWdjcW/tWnh0hCfaBvURvlOa9f5CNVzt7EFkulYbw==" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/emojione/2.2.7/lib/js/emojione.min.js" integrity="sha256-9cBkVeU53NiJ9/BdcJta3HbERAmf5X9DE2WvL8V+gDs=" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jQuery-linkify/2.1.9/linkify.min.js" integrity="sha512-kxj7VjlzsQgiku2vbRcZI0FJ0dXmPsiRLugiRxJrCROusKHaFfX/hGDD1/L/R0Y+xI8zlA2B5nm6USapz7nQbg==" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jQuery-linkify/2.1.9/linkify-string.min.js" integrity="sha512-CMBjJdVIcw7zafkE+uedZCnw6r4ABU1Fev5xA7db0D097/NzhO6Ajo2kdZFOQ+y0kg9sE/t44bPAwuuNhUVIcQ==" crossorigin="anonymous"></script>
     <script type="text/javascript" src="3rdparty/inflate.min.js"></script>
     <script type="text/javascript" src="js/localstorage.js"></script>
     <script type="text/javascript" src="js/weechat.js"></script>

--- a/index.html
+++ b/index.html
@@ -348,7 +348,7 @@ npm run build-electron-{windows, darwin, linux}</pre>
         </div>
 
         <div class="title"  ng-click="showModal('topicModal')">
-          <span class="desktop" ng-repeat="part in activeBuffer().title" ng-class="::part.classes" ng-bind-html="::(part.text | linky:'_blank':{rel:'noopener noreferrer'} | DOMfilter:'irclinky')"></span>
+          <span class="desktop" ng-repeat="part in activeBuffer().title" ng-class="::part.classes" ng-bind-html="::(part.text | conditionalLinkify | DOMfilter:'irclinky')"></span>
           <span class="mobile" ng-class="{'active': activeBuffer().active, 'channel': activeBuffer().type === 'channel', 'channel_hash': activeBuffer().prefix === '#', 'channel_plus': activeBuffer().prefix === '+', 'channel_ampersand': activeBuffer().prefix === '&'}">{{ activeBuffer().trimmedName || activeBuffer().fullName }}</span>
         </div>
 
@@ -628,7 +628,7 @@ npm run build-electron-{windows, darwin, linux}</pre>
           <div class="modal-header">
             <button type="button" class="close" ng-click="closeModal($event)" aria-hidden="true">&times;</button>
             <h4 class="modal-title">Channel topic {{ activeBuffer().shortName || activeBuffer().fullName }}</h4>
-            <span ng-repeat="part in activeBuffer().title" ng-class="::part.classes" ng-bind-html="::(part.text | linky:'_blank':{rel:'noopener noreferrer'} | DOMfilter:'irclinky')"></span>
+            <span ng-repeat="part in activeBuffer().title" ng-class="::part.classes" ng-bind-html="::(part.text | conditionalLinkify | DOMfilter:'irclinky')"></span>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-primary" ng-click="closeModal($event)">Close</button>

--- a/js/filters.js
+++ b/js/filters.js
@@ -66,7 +66,21 @@ weechat.filter('conditionalLinkify', ['$filter', function($filter) {
         if (!text || disable) {
             return text;
         }
-        return $filter('linky')(text, '_blank', {rel:'noopener noreferrer'});
+
+        return linkifyStr(text, {
+            className: '',
+            attributes: {
+                rel: 'noopener noreferrer'
+            },
+            target: {
+                url: '_blank'
+            },
+            validate: {
+                email: function () {
+                    return false; //Do not linkify emails
+                }
+            }
+          });
     };
 }]);
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "karma": "^5.1.0",
     "karma-jasmine": "~3.1",
     "karma-junit-reporter": "~2.0",
-    "karma-phantomjs-launcher": "^1.0.0",
+    "karma-phantomjs-launcher": "^1.0.4",
+    "linkifyjs": "^2.1.9",
     "protractor": "^7.0.0",
     "shelljs": "^0.8.4",
     "uglify-js": "^3.10.0"

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -10,6 +10,8 @@ module.exports = function(config){
       'bower_components/angular-sanitize/angular-sanitize.js',
       'bower_components/angular-touch/angular-touch.js',
       'bower_components/underscore/underscore.js',
+      'node_modules/linkifyjs/dist/linkify.js',
+      'node_modules/linkifyjs/dist/linkify-string.js',
       'js/localstorage.js',
       'js/weechat.js',
       'js/irc-utils.js',

--- a/test/unit/filters.js
+++ b/test/unit/filters.js
@@ -10,6 +10,22 @@ describe('Filters', function() {
         expect($filter('irclinky')).not.toBeNull();
     }));
 
+    describe('conditionalLinkify', function() {
+        it('should create links from an url', inject(function($filter) {
+            var url = 'asdf https://a.example.com/wiki/asdf_qwer_(rivi%C3%A8re) Some text.',
+                link = 'asdf <a href="https://a.example.com/wiki/asdf_qwer_(rivi%C3%A8re)" target="_blank" rel="noopener noreferrer">https://a.example.com/wiki/asdf_qwer_(rivi%C3%A8re)</a> Some text.',
+                result = $filter('conditionalLinkify')(url);
+            expect(result).toEqual(link);        
+        }));
+
+        it('should not make emails into links', inject(function($filter) {
+            var url = 'asdf@gmail.com',
+                link = 'asdf@gmail.com',
+                result = $filter('conditionalLinkify')(url);
+            expect(result).toEqual(link);        
+        }));
+    });
+
     describe('irclinky', function() {
         it('should not mess up text', inject(function(irclinkyFilter) {
             expect(irclinkyFilter('foo')).toEqual('foo');
@@ -23,9 +39,9 @@ describe('Filters', function() {
             expect(irclinkyFilter('<"#foo">')).toEqual('<"<a href="#" onclick="openBuffer(\'#foo">\');">#foo"></a>');
         }));
 
-        it('should not touch links created by `linky`', inject(function(linkyFilter, DOMfilterFilter) {
+        it('should not touch links created by `linky`', inject(function($filter, DOMfilterFilter) {
             var url = 'http://foo.bar/#baz',
-                link = linkyFilter(url, '_blank'),
+                link = $filter('conditionalLinkify')(url),
                 result = DOMfilterFilter(link, 'irclinky').$$unwrapTrustedValue();
             expect(result).toEqual(link);
         }));
@@ -84,9 +100,9 @@ describe('Filters', function() {
             expect(result).toEqual(expected);
         }));
 
-        it('should never lock up like in bug #688', inject(function(linkyFilter, DOMfilterFilter) {
+        it('should never lock up like in bug #688', inject(function($filter, DOMfilterFilter) {
             var msg = '#crash http://google.com',
-                linked = linkyFilter(msg),
+                linked = $filter('conditionalLinkify')(msg),
                 irclinked = DOMfilterFilter(linked, 'irclinky');
             // With the bug, the DOMfilterFilter call ends up in an infinite loop.
             // I.e. if we ever got this far, the bug is fixed.


### PR DESCRIPTION
original pull request #1143 but needed to switch to a new branch.

Wiki links often end in a parenthesis `)`, Linky doesn't include this in the link. This is a [known issue](https://github.com/angular/angular.js/issues/7213).

Since this would be rather hard to fix using linky I turned to a more modern library.
I also added a test.