### PR TITLE
Pause audio, videos and iframe when hiding plugin

### DIFF
--- a/js/plugin-directive.js
+++ b/js/plugin-directive.js
@@ -31,6 +31,24 @@ weechat.directive('plugin', ['$rootScope', 'settings', function($rootScope, sett
 
             $scope.hideContent = function() {
                 $scope.plugin.visible = false;
+                // Pause noise makers
+                var element = $scope.plugin.getElement()
+                // If it's video we can pause it
+                var video = element.querySelector( 'video' );
+                if ( video ) {
+                    video.pause();
+                }
+                // If it's audio we can pause it
+                var audio = element.querySelector( 'audio' );
+                if ( audio ) {
+                    audio.pause();
+                }
+                // If it has an iframe, have to reload it so it would stop
+                var iframe = element.querySelector( 'iframe');
+                if ( iframe ) {
+                    var innerHTML = element.innerHTML;
+                    element.innerHTML = innerHTML;
+                }
             };
 
             $scope.showContent = function(automated) {


### PR DESCRIPTION
This tries to pause videos, audio. If it's an iframe (for example youtube or tiktok) it has to reload the iframe to get it to stop. 
Note this does not pause the videos in iframes such as youtube, so any progress in the video is lost, aswell als already downloaded data.

fixes #975