### PR TITLE
Fix sizing of bufferlines and footer with long links and in general

### DIFF
--- a/css/glowingbear.css
+++ b/css/glowingbear.css
@@ -59,10 +59,6 @@ td.message {
     height: 2px;
 }
 
-.text {
-    white-space: pre-wrap;
-}
-
 #sendMessage {
     width: 100%;
     height: 35px;
@@ -821,8 +817,12 @@ li.buffer.indent.private a {
 
     .content[sidebar-state=visible] #bufferlines, .content[sidebar-state=visible] .footer {
         margin-left: 0px;
+        margin-right: 200px !important;
         transform: translate(200px,0);
         -webkit-transform: translate(200px,0);
+    }
+    .withnicklist[sidebar-state=visible] {
+        margin-right: 300px !important; /* Compensate for the translation */
     }
 
     #topbar .title {
@@ -931,6 +931,10 @@ li.buffer.indent.private a {
 
     .footer.withnicklist {
         padding-right: 108px !important;
+    }
+    .footer.withnicklist[sidebar-state=visible] {
+        padding-right: 200px !important;
+        margin-right: 300px !important; /* Compensate for the translation */
     }
 
     ::-webkit-scrollbar {

--- a/index.html
+++ b/index.html
@@ -445,7 +445,7 @@ npm run build-electron-{windows, darwin, linux}</pre>
           </tbody>
         </table><span id="end-of-buffer"></span>
       </div>
-      <div class="footer" ng-class="{'withnicklist': showNicklist}">
+      <div id="footer" class="footer" ng-class="{'withnicklist': showNicklist}">
         <div input-bar input-id="sendMessage" command="command"></div>
       </div>
     </div>

--- a/js/glowingbear.js
+++ b/js/glowingbear.js
@@ -374,6 +374,8 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     $scope.showSidebar = function() {
         document.getElementById('sidebar').setAttribute('data-state', 'visible');
         document.getElementById('content').setAttribute('sidebar-state', 'visible');
+        document.getElementById('bufferlines').setAttribute('sidebar-state', 'visible');
+        document.getElementById('footer').setAttribute('sidebar-state', 'visible');
         if (utils.isMobileUi()) {
             // de-focus the input bar when opening the sidebar on mobile, so that the keyboard goes down
             _.each(document.getElementsByTagName('textarea'), function(elem) {
@@ -388,6 +390,8 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
             // make sure nicklist is hidden
             document.getElementById('sidebar').setAttribute('data-state', 'hidden');
             document.getElementById('content').setAttribute('sidebar-state', 'hidden');
+            document.getElementById('bufferlines').setAttribute('sidebar-state', 'hidden');
+            document.getElementById('footer').setAttribute('sidebar-state', 'hidden');
         }
         $scope.swipeStatus = 0;
     };


### PR DESCRIPTION
First of all removing `white-space: pre-wrap;` takes care of some sizing issues where long links or long lines of spaces would push the plugin button to the right.

Then all the rest is to get the width right for the content and footer. Here is a table of what bugs it fixes.
To test this, you need to be in a channel that has lines that start with a long section of spaces. And some plugins to propertly see the bugs.

| Size | Before | After | Was ok | Now ok |
| --- | --- | --- | --- | --- |
| Small, no nicklist, no sidebar | [image](https://user-images.githubusercontent.com/23409814/89100019-ffc78180-d3f3-11ea-81ff-585eae48e1c6.png) | [image](https://user-images.githubusercontent.com/23409814/89100021-07872600-d3f4-11ea-9ab3-b3579583d675.png) | ❌ | ✔️ |
| Small, nicklist, no sidebar |  |  | ❌ | ✔️ |
| Small, no nicklist, sidebar | [image](https://user-images.githubusercontent.com/23409814/89099831-6e0b4480-d3f2-11ea-815b-45815c13f3c3.png) | [image](https://user-images.githubusercontent.com/23409814/89099837-7bc0ca00-d3f2-11ea-8717-8e9e8c393885.png) | ❌ | ✔️ |
| Medium, no nicklist, no sidebar |  |  | ❌ | ✔️ |
| Medium, nicklist, no sidebar |  |  | ❌ | ✔️ |
| Medium, no nicklist, sidebar |  |  | ❌ | ✔️ |
| Medium, nicklist, sidebar | [image](https://user-images.githubusercontent.com/23409814/89100054-5a60dd80-d3f4-11ea-8e31-4eaa2e6c5981.png) | [image](https://user-images.githubusercontent.com/23409814/89100058-651b7280-d3f4-11ea-91d2-bbc5eb707d40.png) | ❌ | ✔️ |
| Large, nicklist, sidebar |  |  | ❌ | ✔️ |
| Large, no nicklist, sidebar |  |  | ❌ | ✔️ |

fixes #1136
fixes #888