### PR TITLE
Update uglifyjs command for new version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "linkifyjs": "^2.1.9",
     "protractor": "^7.0.0",
     "shelljs": "^0.8.4",
-    "uglify-js": "^3.10.0"
+    "uglify-js": "^3.10.4"
   },
   "scripts": {
     "postinstall": "bower install -p",
-    "minify": " uglifyjs js/localstorage.js js/weechat.js js/irc-utils.js js/glowingbear.js js/settings.js js/utils.js js/notifications.js js/filters.js js/handlers.js js/connection.js js/file-change.js js/imgur-drop-directive.js js/whenscrolled-directive.js js/inputbar.js js/plugin-directive.js js/websockets.js js/models.js js/bufferResume.js js/plugins.js js/imgur.js -c -m --screw-ie8 -o min.js --source-map url='min.js.map'",
+    "minify": " uglifyjs js/localstorage.js js/weechat.js js/irc-utils.js js/glowingbear.js js/settings.js js/utils.js js/notifications.js js/filters.js js/handlers.js js/connection.js js/file-change.js js/imgur-drop-directive.js js/whenscrolled-directive.js js/inputbar.js js/plugin-directive.js js/websockets.js js/models.js js/bufferResume.js js/plugins.js js/imgur.js -c -m -o min.js --source-map url='min.js.map'",
     "prestart": "npm install",
     "start": "http-server -a localhost -p 8000",
     "pretest": "npm install",


### PR DESCRIPTION
In v3.10.4 uglifyjs renamed the --screw-ie8 parameter to --ie8.

More details in this commit.
https://github.com/mishoo/UglifyJS/commit/ec443e422c220619fe671166e467d3d8838b0cab