### PR TITLE
Fix tab completion

### DIFF
--- a/src/js/irc-utils.js
+++ b/src/js/irc-utils.js
@@ -1,8 +1,8 @@
 /**
  * Portable utilities for IRC.
  */
+import {sortBy, pluck} from "underscore";
 
-(function() {
 'use strict';
 
 var IrcUtils = angular.module('IrcUtils', []);
@@ -25,10 +25,10 @@ IrcUtils.service('IrcUtils', [function() {
      */
     var _ciNickList = function(nickList) {
 
-        var newList = _(nickList).sortBy(function(nickObj) {
+        var newList = sortBy(nickList, function(nickObj) {
             return -nickObj.spokeAt;
         });
-        newList = _(newList).pluck('name');
+        newList = pluck(newList, 'name');
 
         return newList;
     };
@@ -236,4 +236,3 @@ IrcUtils.service('IrcUtils', [function() {
         'completeNick': completeNick
     };
 }]);
-})();


### PR DESCRIPTION
Fixes #1169.

Note that this doesn't use `import * as _ from "underscore";` - instead, it only imports the functions it needs for [tree shaking](https://webpack.js.org/guides/tree-shaking/) purposes. This doesn't help that much when done by itself, but I'm hoping that this is done in other files to get the full benefits of tree shaking.