### PR TITLE
Revert "Change handshake timout to 200ms"

### DIFF
--- a/src/js/connection.js
+++ b/src/js/connection.js
@@ -51,7 +51,7 @@ export const connectionFactory = ['$rootScope', '$log', 'handlers', 'models', 's
                     // too high, this time should be reduced if determined the weechat
                     // is lower than 2.9
                     // This time also includes the time it takes to generate the hash
-                    var WAIT_TIME_OLD_WEECHAT = 200; //ms
+                    var WAIT_TIME_OLD_WEECHAT = 2000; //ms
 
                     // Wait long enough to assume we are on a version < 2.9
                     var handShakeTimeout = setTimeout(function () {


### PR DESCRIPTION
This reverts commit 5fb51c07e6a5bd2777c2cf4a7ae300419878c5b5.

200ms is too little for some setups, and will make authentication not
work even with weechat>=3.0.

For a specific example, my VPN setup has a roundtrip of 300ms.