### PR TITLE
Issue #1263: Desynchronized nicklist

### DIFF
--- a/src/js/models.js
+++ b/src/js/models.js
@@ -160,7 +160,7 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
             }
             for (i in group.nicks) {
                 if (group.nicks[i].name == nick.name) {
-                    delete group.nicks[i];
+                    group.nicks.splice(i, 1);
                     break;
                 }
             }


### PR DESCRIPTION
This is fallout from #1244, which moved models.delNick from using a filter to using the delete operator.

The delete operator creates a sparse array that has an empty slot for the item that was deleted. This empty slot is iterable with some constructs, giving a value of undefined. These unexpected undefined values in the nicklist cause exceptions to be thrown in some situations, like when calling models.updateNickSpeak.

To fix this, use Array.splice to remove elements from the nicklist, instead of the delete operator.