### PR TITLE
update references from ssl to tls to be in-line with weechat

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -39,7 +39,7 @@
       <div class="alert alert-danger" ng-show="errorMessage" ng-cloak>
         <strong>Connection error</strong> The client was unable to connect to the WeeChat relay
       </div>
-      <div class="alert alert-danger" ng-show="sslError" ng-cloak>
+      <div class="alert alert-danger" ng-show="tlsError" ng-cloak>
         <strong>Secure connection error</strong> A secure connection with the WeeChat relay could not be initiated. This is most likely because your browser does not trust your relay's certificate. Please read the encryption instructions below!
       </div>
       <div class="alert alert-danger" ng-show="securityError" ng-cloak>
@@ -109,8 +109,8 @@
                     Error: wrong password or token
                   </div>
                   <div class="checkbox">
-                    <label class="control-label" for="ssl">
-                      <input type="checkbox" id="ssl" ng-model="settings.ssl">
+                    <label class="control-label" for="tls">
+                      <input type="checkbox" id="tls" ng-model="settings.tls">
                       Encryption. <strong>Strongly recommended!</strong> Need help? Check below.
                     </label>
                   </div>
@@ -163,16 +163,16 @@
               <p><strong>If you don't have a domain</strong> you can get a free subdomain from providers such as <a href="https://freedns.afraid.org/">afraid</a>. You'll want to set up an 'A' record to your server's IP address, and quite possibly an AAAA record to its IPv6 address. These might take a few hours to propagate, if the steps below don't work right away, try again in a few hours.</p>
               <p><strong>Getting a certificate</strong> is easy. You'll need certbot—just follow the encryptions at <a href="https://certbot.eff.org/">https://certbot.eff.org</a>. If you're not serving webpages on the same server or are unsure, select "none of the above" (if you are, you can probably use that webserver to proxy your relay, and skip this—check out the <a href="https://github.com/glowing-bear/glowing-bear/wiki/Proxying-WeeChat-relay-with-a-web-server">instructions in our Wiki</a>). Next, get the certificate with <code>certbot certonly --standalone -d {{ settings.host || your.domain.com }}</code> and follow the instructions.</p>
               <p>Nearly done! Now you just need to copy the files into place. To do that, use the following commands, replacing the <strong>username</strong> placeholder with your actual username:</p>
-                <pre>mkdir -p ~<strong>username</strong>/.weechat/ssl
-cat /etc/letsencrypt/live/{{ settings.host || your.domain.com }}/{fullchain,privkey}.pem &gt; ~<strong>username</strong>/.weechat/ssl/relay.pem
-chown -R <strong>username</strong>:<strong>username</strong> ~<strong>username</strong>/.weechat/ssl/</pre>
+                <pre>mkdir -p ~<strong>username</strong>/.weechat/certs
+cat /etc/letsencrypt/live/{{ settings.host || your.domain.com }}/{fullchain,privkey}.pem &gt; ~<strong>username</strong>/.weechat/certs/relay.pem
+chown -R <strong>username</strong>:<strong>username</strong> ~<strong>username</strong>/.weechat/certs/</pre>
               <p>Once you've got the certificate and moved it in place, you can set up an encrypted relay on port {{ settings.port || 9001 }} with these WeeChat commands:</p>
 <pre>
 /set relay.network.password y0ur_StRonG-pa$sw0rd:of*choice
-/relay sslcertkey
-/relay add ssl.weechat {{ settings.port || 9001 }}
+/relay tlscertkey
+/relay add tls.weechat {{ settings.port || 9001 }}
 </pre>
-              <p>Your certificate needs to be renewed every couple of months. Either follow the instructions for automatic renewal at <a href="https://certbot.eff.org/">https://certbot.eff.org</a>, or run <code>certbot renew</code> manually when renewal is due. <strong>Important:</strong> You'll need to follow the instructions for copying the certificate to the right place again, and re-run <code>/relay sslcertkey</code> in WeeChat.</p>
+              <p>Your certificate needs to be renewed every couple of months. Either follow the instructions for automatic renewal at <a href="https://certbot.eff.org/">https://certbot.eff.org</a>, or run <code>certbot renew</code> manually when renewal is due. <strong>Important:</strong> You'll need to follow the instructions for copying the certificate to the right place again, and re-run <code>/relay tlscertkey</code> in WeeChat.</p>
               <h3>Use TOTP (Time-based One-Time Password)</h3>
               <p><a href="https://blog.weechat.org/post/2019/01/14/Support-of-TOTP">Configure</a> WeeChat for TOTP. The secret key has to be a base 32 string.</p>
               <pre>/secure set relay_totp_secret xxxxx

--- a/src/js/connection.js
+++ b/src/js/connection.js
@@ -24,17 +24,17 @@ export const connectionFactory = ['$rootScope', '$log', 'handlers', 'models', 's
     var locked = false;
 
     // Takes care of the connection and websocket hooks
-    var connect = function (host, port, path, passwd, ssl, useTotp, totp, noCompression, successCallback, failCallback) {
+    var connect = function (host, port, path, passwd, tls, useTotp, totp, noCompression, successCallback, failCallback) {
         $rootScope.passwordError = false;
         $rootScope.oldWeechatError = false;
         $rootScope.hashAlgorithmDisagree = false;
-        connectionData = [host, port, path, passwd, ssl, noCompression];
-        
+        connectionData = [host, port, path, passwd, tls, noCompression];
+
         // https://github.com/glowing-bear/glowing-bear/issues/1157
         var isSecureContext = window.isSecureContext;
         var weechatPre2_9 = settings.compatibilityWeechat28;
 
-        var proto = ssl ? 'wss' : 'ws'; 
+        var proto = tls ? 'wss' : 'ws';
         // If host is an IPv6 literal wrap it in brackets
         if (host.indexOf(":") !== -1 && host[0] !== "[" && host[host.length-1] !== "]") {
             host = "[" + host + "]";
@@ -387,7 +387,7 @@ export const connectionFactory = ['$rootScope', '$log', 'handlers', 'models', 's
                 }
 
             },
-            
+
             //Sending version failed
             function() {
                 handleWrongPassword();
@@ -411,11 +411,11 @@ export const connectionFactory = ['$rootScope', '$log', 'handlers', 'models', 's
         };
 
         handleClose = function (evt) {
-            if (ssl && evt && evt.code === 1006) {
+            if (tls && evt && evt.code === 1006) {
                 // A password error doesn't trigger onerror, but certificate issues do. Check time of last error.
                 if (typeof $rootScope.lastError !== "undefined" && (Date.now() - $rootScope.lastError) < 1000) {
-                    // abnormal disconnect by client, most likely ssl error
-                    $rootScope.sslError = true;
+                    // abnormal disconnect by client, most likely tls error
+                    $rootScope.tlsError = true;
                     $rootScope.$apply();
                 }
             }

--- a/src/js/glowingbear.js
+++ b/src/js/glowingbear.js
@@ -56,7 +56,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         'hostField': 'localhost',
         'port': 9001,
         'path': 'weechat',
-        'ssl': (window.location.protocol === "https:"),
+        'tls': (window.location.protocol === "https:"),
         'compatibilityWeechat28': false,
         'useTotp': false,
         'savepassword': false,
@@ -85,7 +85,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     //For upgrade reasons because we changed the name of host to hostField
     //check if the value might still be in the host key instead of the hostField key
     if (!settings.hostField && settings.host) {
-        settings.hostField = settings.host; 
+        settings.hostField = settings.host;
     }
 
     $rootScope.countWatchers = function () {
@@ -261,7 +261,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     });
 
     $rootScope.favico = new Favico({animation: 'none'});
-    
+
     $scope.notifications = notifications.unreadCount('notification');
     $scope.unread = notifications.unreadCount('unread');
 
@@ -402,7 +402,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     };
 
     settings.addCallback('autoconnect', function(autoconnect) {
-        if (autoconnect && !$rootScope.connected && !$rootScope.sslError && !$rootScope.securityError && !$rootScope.errorMessage) {
+        if (autoconnect && !$rootScope.connected && !$rootScope.tlsError && !$rootScope.securityError && !$rootScope.errorMessage) {
             $scope.connect();
         }
     });
@@ -672,9 +672,9 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         if ((parts = regexProto.exec(settings.hostField)) !== null) {
             settings.hostField = parts[2];
             if (parts[1] === "http" || parts[1] === "ws") {
-                settings.ssl = false;
+                settings.tls = false;
             } else if (parts[1] === "https" || parts[1] === "wss") {
-                settings.ssl = true;
+                settings.tls = true;
             }
         }
 
@@ -738,13 +738,13 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
     $scope.connect = function() {
         document.getElementById('audioNotificationInitializer').play(); // Plays some silence, this will enable autoplay for notifications
         notifications.requestNotificationPermission();
-        $rootScope.sslError = false;
+        $rootScope.tlsError = false;
         $rootScope.securityError = false;
         $rootScope.errorMessage = false;
         $rootScope.bufferBottom = true;
         $scope.connectbutton = 'Connecting';
         $scope.connectbuttonicon = 'glyphicon-refresh glyphicon-spin';
-        connection.connect(settings.host, settings.port, settings.path, $scope.password, settings.ssl, settings.useTotp, $scope.totp);
+        connection.connect(settings.host, settings.port, settings.path, $scope.password, settings.tls, settings.useTotp, $scope.totp);
         $scope.totp = ""; // Clear for next time
     };
 
@@ -754,7 +754,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         bufferResume.reset();
         connection.disconnect();
     };
-    
+
     $scope.reconnect = function() {
         var bufferId = models.getActiveBuffer().id;
         connection.attemptReconnect(bufferId, 3000);


### PR DESCRIPTION
There are a few references to configuration parameters which no longer exist as they reference ssl rather than tls in versions >= 4.0.0 as per https://github.com/weechat/weechat/issues/1903