### PR TITLE
add docker image pushing to ghcr.io/glowing-bear/glowing-bear, and automated test runs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+bower_components/
+node_modules/
+
+# Electron stuff
+fonts/
+Glowing\ Bear-*/
+
+# local build products
+build/ 
+
+# IntelliJ / WebStorm
+.idea/
+
+# don't transfer in things not used, but easily invalidating cache.
+Dockerfile
+.git/

--- a/.github/workflows/test-and-push.yml
+++ b/.github/workflows/test-and-push.yml
@@ -1,0 +1,53 @@
+name: Create and publish a Docker image
+
+on: [push]
+
+env:
+  REGISTRY: ghcr.io
+  TAGGED_IMAGE_NAME: ${{ github.repository }}:${{ github.ref_type == 'tag' && github.ref_name || 'latest' }}
+  # if you're a fork and trying to self publish, add ENABLE_PUSH to your fork's action environment variables.
+  # centralize this logic here, but due to GH, this means the result is a string.  So consumers must do a `== 'true'` check.  Blame GH.
+  ENABLE_PUSH: ${{ (vars.ENABLE_PUSH || github.repository == 'glowing-bear/glowing-bear') && ((github.ref_type == 'tag' && startswith(github.ref_name, 'v')) || github.ref_name == 'master' ) }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install Xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      - name: npm install
+        run: npm install --include=dev
+
+      - name: run test
+        run: xvfb-run ./run_tests.sh
+
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    needs: [tests]
+
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v5
+
+      - name: GHCR login
+        uses: docker/login-action@v3
+        if: env.ENABLE_PUSH == 'true'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ env.ENABLE_PUSH }}
+          tags: ${{ env.REGISTRY }}/${{ env.TAGGED_IMAGE_NAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY . ./
 RUN npm install && npm run build
 
-FROM docker.io/joseluisq/static-web-server:2.14.1
+FROM docker.io/joseluisq/static-web-server:2.39.0
 COPY --from=builder /app/build /content/
 USER 3000
 ENV SERVER_LOG_LEVEL=info

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY . ./
+RUN npm install && npm run build
+
+FROM docker.io/joseluisq/static-web-server:2.14.1
+COPY --from=builder /app/build /content/
+USER 3000
+ENV SERVER_LOG_LEVEL=info
+ENTRYPOINT ["/static-web-server", "--port=8080", "--root=/content"]


### PR DESCRIPTION
Per the title, this makes an OCI image available via your ghcr.io repo namespace.  This pushes `:latest` for changes to `master`, and pushes tagged versions for tags.

For sanity sake, that's wired to only run if tests pass.  Whilst you have some travis-ci configs, that looks dead- perhaps rewire to the GH actions instead?

A point of discussion is that I'm injecting a rust static file webserver in to the image to serve the resultant content- being you've got tauri, please double check if the static server thing I did is actually needed.  For some reason I recall tauri as being able to be a standalone web server.