### PR TITLE
Fix duplicate lines on reconnect (closes #1147)

### DIFF
--- a/src/js/connection.js
+++ b/src/js/connection.js
@@ -449,8 +449,8 @@ export const connectionFactory = ['$rootScope', '$log', 'handlers', 'models', 's
         if (locked) {
             // We already have an open connection
             $log.debug("Aborting connection (lock in use)");
+            return;
         }
-        // Kinda need a compare-and-swap here...
         locked = true;
 
         try {
@@ -532,6 +532,7 @@ export const connectionFactory = ['$rootScope', '$log', 'handlers', 'models', 's
         var bufferId = models.getActiveBuffer().id,
             timeout = 3000;  // start with a three-second timeout
 
+        clearTimeout(reconnectTimer);
         reconnectTimer = setTimeout(function() {
             attemptReconnect(bufferId, timeout);
         }, timeout);

--- a/src/js/websockets.js
+++ b/src/js/websockets.js
@@ -120,6 +120,9 @@ function($rootScope, $q) {
                            protocol_,
                            properties) {
 
+        if (ws !== null && ws.readyState !== WebSocket.CLOSED) {
+            ws.close();
+        }
         ws = new WebSocket(url);
         protocol = protocol_;
         for (var property in properties) {


### PR DESCRIPTION
## Problem

After a connection loss and reconnect, all chat lines would appear duplicated — 2× after one reconnect cycle, 3× after two, and so on. Tracked in #1147.

## Root cause

Three cooperating bugs caused an ever-growing number of live WebSocket connections, each with its own `sync *` subscription to WeeChat. WeeChat broadcast `_buffer_line_added` to every subscriber and the app appended each delivery as a new line.

1. **Missing `return` in the connection lock check** (`connection.js`): the `if (locked) { … }` block logged a message but didn't return, so the check was bypassed and a second connection could be established while the first was still live.

2. **Stacking reconnect timers** (`connection.js`): `reconnect()` never called `clearTimeout(reconnectTimer)` before scheduling a new one. After *N* disconnects there were *N* concurrent timers, all eventually firing and each calling `connect()`.

3. **Orphaned WebSocket** (`websockets.js`): `connect()` assigned `ws = new WebSocket(url)` without closing the previous socket first. The old socket remained open and continued receiving push events from WeeChat.

## Fix

- Add the missing `return` after the lock check.
- Call `clearTimeout(reconnectTimer)` before scheduling a new reconnect timer.
- Close the existing WebSocket (if not already closed) before creating a new one.

Fixes #1147

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)