### PR TITLE
Cleanup: remove Libera banner, drop WeeChat 2.8 compat mode, update minimum version to 2.9

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Glowing Bear is a browser-based frontend for the WeeChat IRC client. It speaks the WeeChat relay protocol directly over WebSockets — there is **no backend service**. All code is client-side JavaScript (AngularJS 1.x) plus an optional Tauri wrapper (Rust) for native desktop apps. The user's browser connects straight to their WeeChat instance.
 
-Requires WeeChat ≥ 0.4.2 on the server side. There is a compatibility shim for WeeChat 2.8 vs ≥ 2.9 around the handshake / password hashing (`settings.compatibilityWeechat28`).
+Requires WeeChat ≥ 2.9 on the server side.
 
 ## Common commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Glowing Bear is a browser-based frontend for the WeeChat IRC client. It speaks the WeeChat relay protocol directly over WebSockets — there is **no backend service**. All code is client-side JavaScript (AngularJS 1.x) plus an optional Tauri wrapper (Rust) for native desktop apps. The user's browser connects straight to their WeeChat instance.
+
+Requires WeeChat ≥ 0.4.2 on the server side. There is a compatibility shim for WeeChat 2.8 vs ≥ 2.9 around the handshake / password hashing (`settings.compatibilityWeechat28`).
+
+## Common commands
+
+```bash
+npm install              # install deps (runs automatically before `start`)
+npm start                # webpack dev server on http://localhost:8000 with live reload
+npm run build            # production build into build/
+npm run lint             # jshint over src/js/*.js and test/unit/*.js
+npm test                 # karma + jasmine unit tests (single run; uses webpack preprocessor)
+npm run protractor       # e2e tests — REQUIRES Glowing Bear on :8000 AND WeeChat relay on :9001
+./run_tests.sh           # what CI runs: lint + unit tests
+npm run tauri -- dev     # run the Tauri desktop wrapper in dev mode
+npm run tauri -- build   # build native desktop bundles
+```
+
+Single-test runs: there is no built-in filter flag; edit `test/unit/main.test.js` to import only the spec you want, or use Jasmine's `fdescribe` / `fit` to focus.
+
+The Karma config (`test/karma.conf.js`) auto-switches to `ChromeHeadlessNoSandbox` under `TRAVIS=1`. For headless local runs without a display, set that env var or add a custom launcher.
+
+## Architecture
+
+Entry point is `src/main.js`, which imports every AngularJS module under `src/js/`. Webpack bundles everything; `src/index.html` is the shell that Angular boots into. There is **no router-driven view layout** — the whole UI lives in `src/index.html` with directives in `src/directives/` (`input.html`, `plugin.html`).
+
+The codebase splits cleanly into protocol vs. UI:
+
+### Protocol layer (network-agnostic)
+- **`src/js/weechat.js`** (~1400 lines) — pure parser/encoder for the WeeChat binary relay protocol. Knows nothing about WebSockets. Decodes types (`chr`, `int`, `str`, `hda`, `ptr`, `tim`, `arr`, `htb`, `inl`, …), handles zlib-compressed frames (via `zlibjs`), and produces JS objects. Also contains the rich-text/color parser (`rawText2Rich`) used by the UI to render WeeChat color codes.
+- **`src/js/websockets.js`** (`ngWebsockets` factory) — thin WebSocket transport. Sends commands, matches responses to callbacks by id, exposes promise-based send.
+- **`src/js/connection.js`** (`connection` factory) — orchestration: open/close/reconnect, handshake (`compatibilityWeechat28` switch between plaintext password and PBKDF2/SHA-512), TOTP, hotlist polling interval, ping/pong keepalive. **Do not call `ngWebsockets` directly from controllers — go through `connection`.**
+
+### Domain / state
+- **`src/js/models.js`** (`models` service) — the single source of truth for buffers, lines, nicklists, the WeeChat version, and `wconfig`. UI watches scopes on these models.
+- **`src/js/handlers.js`** — dispatch table that takes parsed protocol messages and mutates `models` accordingly (`_buffer_line_added`, `_nicklist`, `_buffer_opened`, etc.).
+- **`src/js/bufferResume.js`** — tracks which buffer was last viewed so reconnect lands the user in the right place.
+
+### UI
+- **`src/js/glowingbear.js`** (~1000 lines) — the main `WeechatCtrl` controller. Handles settings defaults, theme switching, mobile swipe state, the buffer list, notifications wiring, focus/scroll. Imports `connectionFactory` from `connection.js` and registers it as the `connection` service.
+- **`src/js/inputbar.js`** (~800 lines) — chat input directive with readline-style keybindings, history, tab completion (delegates to `irc-utils.js` for nick completion).
+- **`src/js/plugin-directive.js`** + **`src/directives/plugin.html`** — renders embedded plugin output (image previews, video embeds, etc.).
+- **`src/js/imgur*.js`** — Imgur upload integration (drag-and-drop in `imgur-drop-directive.js`).
+- **`src/js/filters.js`** — Angular filters used in templates (highlighting, IRC color → HTML, etc.).
+- **`src/js/notifications.js`** — desktop notifications, sound, favicon badge (`favico.js`).
+- **`src/js/settings.js`** + **`src/js/localstorage.js`** — settings with localStorage persistence. Every setting must be declared in `settings.setDefaults({...})` in `glowingbear.js` or it won't persist.
+
+### Plugins (content embedding)
+- **`src/js/plugins.js`** defines `Plugin` (matches against message text) and `UrlPlugin` (matches URLs via a regex). The plugin registry lives in the `plugins` Angular module. To add an embed type, append a new `Plugin`/`UrlPlugin` to the array in this file. **Anything injected into the DOM via `innerHTML` must be sanitized** — the codebase has had XSS regressions here; see recent commits about sanitizing gist/tweet/tiktok HTML before insertion.
+
+### Tauri wrapper
+`src-tauri/` is a thin Rust shell that loads the built web app. `tauri.conf.json` points `distDir` at `../build` and `devPath` at the webpack dev server. It uses `tauri-plugin-window-state` for window persistence.
+
+## Conventions
+
+- AngularJS 1.x dependency-injection arrays are used everywhere (`['$scope', ..., function($scope, ...){}]`). Adding a new dependency requires updating both the array and the function signature.
+- `jshint` is configured for `esversion: 6` (`.jshintrc`); ES module syntax in source is handled by Babel via webpack.
+- Globals whitelisted by jshint: `angular`, `weeChat`, `Notification`, `linkifyStr`, `renderMathInElement`, `emojione`, `escape`.
+- Themes are CSS files directly under `src/css/` (e.g. `dark.css`, `light.css`, `base16-*.css`) — register new themes in the `$scope.themes` array in `glowingbear.js`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Glowing Bear is a web frontend for the [WeeChat](https://weechat.org) IRC client
 
 ## Getting Started
 
-Glowing Bear connects to the WeeChat instance you're already running (version 0.4.2 or later is required), and you need to be able to establish a connection to the WeeChat host from your device. It makes use of the relay plugin, and therefore you need to set up a relay. If you want to try this out with a local WeeChat instance, use these commands in WeeChat to create an **unencrypted relay** (see the note below):
+Glowing Bear connects to the WeeChat instance you're already running (version 2.9 or later is required), and you need to be able to establish a connection to the WeeChat host from your device. It makes use of the relay plugin, and therefore you need to set up a relay. If you want to try this out with a local WeeChat instance, use these commands in WeeChat to create an **unencrypted relay** (see the note below):
 
 	/relay add weechat 9001
 	/set relay.network.password YOURPASSWORD

--- a/src/index.html
+++ b/src/index.html
@@ -51,10 +51,6 @@
       <div class="alert alert-danger" ng-show="hashAlgorithmDisagree" ng-cloak>
         <strong>Hash algorithm error</strong> Weechat and glowing bear did not agree on a hashing algorithm, please do /set relay.network.password_hash_algo "pbkdf2+sha512" or "plain" (when using http-only) in weechat.
       </div>
-      <div class="alert alert-warning alert-dismissible" role="alert" ng-hide="settings.freenodeWarningRead">
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close" ng-click="settings.freenodeWarningRead=1"><span aria-hidden="true">&times;</span></button>
-        <strong>Our channel has moved to Libera Chat!</strong> Freenode is no longer trustworthy - they have hijacked our channel on their network, and we strongly recommend all users to join us in #glowing-bear on <a href="https://libera.chat/">Libera Chat</a> instead. The same goes for WeeChat&apos;s channel, #weechat, and many other open source projects.
-      </div>
       <div class="panel-group accordion">
         <div class="panel" data-state="active" ng-show=false>
           <div class="panel-heading">

--- a/src/index.html
+++ b/src/index.html
@@ -46,7 +46,7 @@
         <strong>Secure connection error</strong> Unable to connect to unencrypted relay when you are connecting to Glowing Bear over HTTPS. Please use an encrypted relay or load the page without using HTTPS.
       </div>
       <div class="alert alert-danger" ng-show="oldWeechatError" ng-cloak>
-        <strong>Weechat version error</strong> Weechat connected but did not respond to a handshake. This could mean weechat &lt; version 2.9. Verify your weechat is 2.8 or older and check "Compatibility with Weechat 2.8 and older" or consider updating weechat.
+        <strong>Weechat version error</strong> Weechat connected but did not respond to a handshake. This likely means your WeeChat version is older than 2.9. Please update WeeChat.
       </div>
       <div class="alert alert-danger" ng-show="hashAlgorithmDisagree" ng-cloak>
         <strong>Hash algorithm error</strong> Weechat and glowing bear did not agree on a hashing algorithm, please do /set relay.network.password_hash_algo "pbkdf2+sha512" or "plain" (when using http-only) in weechat.
@@ -111,19 +111,6 @@
                     </label>
                   </div>
                   <div class="checkbox">
-                    <label class="control-label" for="compatibilityWeechat28">
-                      <input type="checkbox" id="compatibilityWeechat28" ng-model="settings.compatibilityWeechat28">
-                      Compatibility with Weechat 2.8 and older <a href="#plaintext" ng-click="toggleAccordionByName('gettingStartedAccordion')"><i class="glyphicon glyphicon-info-sign"></i></a>
-                      <span style="color: #888;display:block">WeeChat 2.9 was released in July 2020, so you should not need to enable this if you&apos;re anywhere close to up to date.</span>
-                    </label>
-                  </div>
-                  <div class="checkbox indent" ng-show="settings.compatibilityWeechat28">
-                    <label class="control-label" for="useTotp">
-                      <input type="checkbox" id="useTotp" ng-model="settings.useTotp">
-                      Use Time-based One-Time Password (automatic for Weechat &gt;= 2.9)<a href="https://blog.weechat.org/post/2019/01/14/Support-of-TOTP" target="_blank"><i class="glyphicon glyphicon-info-sign"></i></a>
-                    </label>
-                  </div>
-                  <div class="checkbox">
                     <label class="control-label" for="savepassword">
                         <input type="checkbox" id="savepassword" ng-model="settings.savepassword">
                         Save password in your browser
@@ -131,12 +118,12 @@
                   </div>
                   <div class="checkbox" ng-show="settings.savepassword || settings.autoconnect">
                     <label class="control-label" for="autoconnect">
-                        <input type="checkbox" id="autoconnect" ng-model="settings.autoconnect"  ng-disabled="settings.compatibilityWeechat28 && settings.useTotp">
+                        <input type="checkbox" id="autoconnect" ng-model="settings.autoconnect">
                         Automatically connect
                     </label>
                   </div>
                 </div>
-                <button class="btn btn-lg btn-primary" ng-disabled="hostInvalid || (totpInvalid && settings.useTotp)" ng-click="connect()" ng-cloak>{{ connectbutton }}  <i ng-class="connectbuttonicon" class="glyphicon"></i></button>
+                <button class="btn btn-lg btn-primary" ng-disabled="hostInvalid" ng-click="connect()" ng-cloak>{{ connectbutton }}  <i ng-class="connectbuttonicon" class="glyphicon"></i></button>
               </form>
             </div>
           </div>
@@ -175,12 +162,6 @@ chown -R <strong>username</strong>:<strong>username</strong> ~<strong>username</
 /set relay.network.totp_secret "${sec.data.relay_totp_secret}"</pre>
               <p>Open an authenticator app and create an entry with the same secret. In Glowing Bear check the checkbox for "use Time-based One-Time Password" and fill in the one time password as you see it in the authenticator app.</p>
 
-              <h3><a name="plaintext"></a>Compatibility with WeeChat 2.8 and older</h3>
-              <p><strong>Required for WeeChat <= 2.8</strong></p>
-              <p>With WeeChat 2.9—released in July 2020—relay client authentication was made more secure and resistant to brute forcing. Glowing Bear uses the most secure authentication method by default. However, to support older versions of WeeChat, this option allows Glowing Bear to still use the old authentication method, sending your password to WeeChat (in plain text if you are not using encryption!). Only enable this if you are using a WeeChat version before 2.9!</p>
-              <p>By default, WeeChat 2.9 support several authentication methods.  Of these, Glowing Bear only uses the most secure one, <code>pbkdf2+sha512</code>. You can check the list of enabled methods to ensure it is in there:
-                <code>/set relay.network.password_hash_algo</code>
-              </p>
             </div>
           </div>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -138,7 +138,7 @@
           </div>
           <div id="collapseTwo" class="panel-collapse collapse">
             <div class="panel-body">
-              <p><span class="label label-danger">WeeChat version 0.4.2 or higher is required, but WeeChat 2.9 or later is recommended for the best experience.</p>
+              <p><span class="label label-danger">WeeChat version 2.9 or later is required.</p>
               <h3>Use TLS encryption</h3>
               <p>To start using Glowing Bear, follow the instructions below to set up an encrypted relay. All communication goes directly between your browser and your WeeChat relay! This means that your server must be accessible. We never see any of your data or your password, and you don't need to trust a "cloud". All settings, including your password, are saved locally in your own browser between sessions.</p>
               <div class="alert alert-warning" ng-show="show_tls_warning"><strong>You're using Glowing Bear over an unencrypted connection (http://). This is not recommended!</strong> We recommend using our secure hosted version at <a href="https://www.glowing-bear.org/">https://www.glowing-bear.org/</a>, or <a href="https://latest.glowing-bear.org/">https://latest.glowing-bear.org</a> for the latest and greatest development version. You can still follow the instructions below to set up an encrypted relay, though.</div>

--- a/src/js/connection.js
+++ b/src/js/connection.js
@@ -92,27 +92,6 @@ export const connectionFactory = ['$rootScope', '$log', 'handlers', 'models', 's
             };
 
             // Helper methods for initialization commands
-            // Used for plain-text authentication (non-secure contexts)
-            var _initializeConnectionPre29 = function(passwd, totp) {
-                // Escape comma in password (#937)
-                passwd = passwd.replace(',', '\\,');
-
-                ngWebsockets.send(
-                    weeChat.Protocol.formatInitPre29({
-                        password: passwd,
-                        compression: noCompression ? 'off' : 'zlib',
-                        totp: totp
-                    })
-                );
-
-                // Wait a little bit until the init is sent
-                return new Promise(function(resolve) {
-                    setTimeout(function() { resolve(); }, 5);
-                });
-
-            };
-
-            // Helper methods for initialization commands
             // This method is used to initialize weechat >= 2.9
             var salt;
             var _initializeConnection29 = function(passwd, nonce, iterations, totp) {
@@ -301,7 +280,13 @@ export const connectionFactory = ['$rootScope', '$log', 'handlers', 'models', 's
                     if (passwordMethod == "pbkdf2+sha512") {
                         return _initializeConnection29(passwd, nonce, iterations, totp);
                     } else if (passwordMethod == "plain") {
-                        return _initializeConnectionPre29(passwd, totp);
+                        // Non-secure context: send plain password using the 2.9+ init format
+                        ngWebsockets.send(
+                            weeChat.Protocol.formatInit29('plain:' + passwd, totp)
+                        );
+                        return new Promise(function(resolve) {
+                            setTimeout(function() { resolve(); }, 5);
+                        });
                     }
                 });
             }).then(function(){

--- a/src/js/connection.js
+++ b/src/js/connection.js
@@ -116,7 +116,7 @@ export const connectionFactory = ['$rootScope', '$log', 'handlers', 'models', 's
                     );
                 }).then(function (hash) {
                     ngWebsockets.send(
-                        weeChat.Protocol.formatInit29(
+                        weeChat.Protocol.formatInit(
                             'pbkdf2+sha512:' + utils.bytetoHexString(salt) + ':' +
                                 iterations + ':' + utils.bytetoHexString(hash),
                             totp
@@ -282,7 +282,7 @@ export const connectionFactory = ['$rootScope', '$log', 'handlers', 'models', 's
                     } else if (passwordMethod == "plain") {
                         // Non-secure context: send plain password using the 2.9+ init format
                         ngWebsockets.send(
-                            weeChat.Protocol.formatInit29('plain:' + passwd, totp)
+                            weeChat.Protocol.formatInit('plain:' + passwd, totp)
                         );
                         return new Promise(function(resolve) {
                             setTimeout(function() { resolve(); }, 5);

--- a/src/js/connection.js
+++ b/src/js/connection.js
@@ -91,10 +91,9 @@ export const connectionFactory = ['$rootScope', '$log', 'handlers', 'models', 's
                 });
             };
 
-            // Helper methods for initialization commands
-            // This method is used to initialize weechat >= 2.9
+            // Initializes the connection using PBKDF2+SHA512 password hashing
             var salt;
-            var _initializeConnection29 = function(passwd, nonce, iterations, totp) {
+            var _initializeConnection = function(passwd, nonce, iterations, totp) {
                 return window.crypto.subtle.importKey(
                     'raw',
                     utils.stringToUTF8Array(passwd),
@@ -278,7 +277,7 @@ export const connectionFactory = ['$rootScope', '$log', 'handlers', 'models', 's
                 return _askTotp(totpRequested)
                 .then(function(totp) {
                     if (passwordMethod == "pbkdf2+sha512") {
-                        return _initializeConnection29(passwd, nonce, iterations, totp);
+                        return _initializeConnection(passwd, nonce, iterations, totp);
                     } else if (passwordMethod == "plain") {
                         // Non-secure context: send plain password using the 2.9+ init format
                         ngWebsockets.send(

--- a/src/js/connection.js
+++ b/src/js/connection.js
@@ -24,7 +24,7 @@ export const connectionFactory = ['$rootScope', '$log', 'handlers', 'models', 's
     var locked = false;
 
     // Takes care of the connection and websocket hooks
-    var connect = function (host, port, path, passwd, tls, useTotp, totp, noCompression, successCallback, failCallback) {
+    var connect = function (host, port, path, passwd, tls, noCompression, successCallback, failCallback) {
         $rootScope.passwordError = false;
         $rootScope.oldWeechatError = false;
         $rootScope.hashAlgorithmDisagree = false;
@@ -32,7 +32,6 @@ export const connectionFactory = ['$rootScope', '$log', 'handlers', 'models', 's
 
         // https://github.com/glowing-bear/glowing-bear/issues/1157
         var isSecureContext = window.isSecureContext;
-        var weechatPre2_9 = settings.compatibilityWeechat28;
 
         var proto = tls ? 'wss' : 'ws';
         // If host is an IPv6 literal wrap it in brackets
@@ -45,49 +44,42 @@ export const connectionFactory = ['$rootScope', '$log', 'handlers', 'models', 's
         var onopen = function () {
             var _performHandshake = function() {
                 return new Promise(function(resolve) {
-                    // 1. Compatability for Weechat 2.8 was activated by the user - skip handshake
-                    // 2. If SecureContext use pbkdf2+sha512 hash
-                    // 3. If !SecureContext use plain text
-                    // If handshake times out we do no longer make the assumption it is Pre 2.9 but just inform the user
+                    // If SecureContext use pbkdf2+sha512 hash, otherwise plain text
+                    // If handshake times out, inform the user their WeeChat is too old
 
-                    if (weechatPre2_9) {
-                        resolve();
+                    var WAIT_TIME_OLD_WEECHAT = 2000; //ms
+                    var handShakeTimeout = setTimeout(function () {
+                        $rootScope.oldWeechatError = true;
+                        $rootScope.$emit('relayDisconnect');
+                        $rootScope.$digest(); // Have to do this otherwise change detection doesn't see the error.
+                        throw new Error('Handshake timed out. Verify Weechat Version.');
+                    }, WAIT_TIME_OLD_WEECHAT);
+
+                    if (isSecureContext) {
+                        ngWebsockets.send(
+                            weeChat.Protocol.formatHandshake({
+                                password_hash_algo: "pbkdf2+sha512", compression: noCompression ? 'off' : 'zlib'
+                            })
+                        ).then(function (message){
+                            clearTimeout(handShakeTimeout);
+                            resolve(message);
+                        });
                     } else {
-                        var WAIT_TIME_OLD_WEECHAT = 2000; //ms
-                        var handShakeTimeout = setTimeout(function () {
-                            $rootScope.oldWeechatError = true;
-                            $rootScope.$emit('relayDisconnect');
-                            $rootScope.$digest(); // Have to do this otherwise change detection doesn't see the error.
-                            throw new Error('Handshake timed out. Verify Weechat Version.');
-                        }, WAIT_TIME_OLD_WEECHAT);
-
-                        if (isSecureContext) {
-                            ngWebsockets.send(
-                                weeChat.Protocol.formatHandshake({
-                                    password_hash_algo: "pbkdf2+sha512", compression: noCompression ? 'off' : 'zlib'
-                                })
-                            ).then(function (message){
-                                clearTimeout(handShakeTimeout);
-                                resolve(message);
-                            });
-                        } else {
-                            ngWebsockets.send(
-                                weeChat.Protocol.formatHandshake({
-                                    password_hash_algo: "plain", compression: noCompression ? 'off' : 'zlib'
-                                })
-                            ).then(function (message){
-                                clearTimeout(handShakeTimeout);
-                                resolve(message);
-                            });
-                        }
+                        ngWebsockets.send(
+                            weeChat.Protocol.formatHandshake({
+                                password_hash_algo: "plain", compression: noCompression ? 'off' : 'zlib'
+                            })
+                        ).then(function (message){
+                            clearTimeout(handShakeTimeout);
+                            resolve(message);
+                        });
                     }
                 });
             };
 
             var _askTotp = function (useTotp) {
                 return new Promise(function(resolve) {
-                    // If weechat is < 2.9 the totp will be a setting (checkbox)
-                    // Otherwise the handshake will specify it
+                    // totpRequested comes from the handshake response
                     if (useTotp) {
                         // Ask the user to input his TOTP
                         var totp = prompt("Please enter your TOTP Token");
@@ -100,7 +92,7 @@ export const connectionFactory = ['$rootScope', '$log', 'handlers', 'models', 's
             };
 
             // Helper methods for initialization commands
-            // This method is used to initialize weechat < 2.9 but only if the User has picked compatibility mode explicitly
+            // Used for plain-text authentication (non-secure contexts)
             var _initializeConnectionPre29 = function(passwd, totp) {
                 // Escape comma in password (#937)
                 passwd = passwd.replace(',', '\\,');
@@ -289,13 +281,6 @@ export const connectionFactory = ['$rootScope', '$log', 'handlers', 'models', 's
             _performHandshake().then(
                 // Wait for weechat to respond or handshake times out
                 function (message) {
-                    // Do nothing if the handshake was received
-                    // after concluding weechat was an old version
-                    // TODO maybe warn the user here
-                    if (weechatPre2_9) {
-                        return;
-                    }
-
                     var content = message.objects[0].content;
                     passwordMethod = content.password_hash_algo;
                     totpRequested = (content.totp === 'on');
@@ -311,23 +296,14 @@ export const connectionFactory = ['$rootScope', '$log', 'handlers', 'models', 's
                     }
                 }
             ).then(function() {
-                if (weechatPre2_9) {
-                    // Ask the user for the TOTP token if this is enabled
-                    return _askTotp(useTotp)
-                    .then(function (totp) {
+                return _askTotp(totpRequested)
+                .then(function(totp) {
+                    if (passwordMethod == "pbkdf2+sha512") {
+                        return _initializeConnection29(passwd, nonce, iterations, totp);
+                    } else if (passwordMethod == "plain") {
                         return _initializeConnectionPre29(passwd, totp);
-                    });
-                } else {
-                    // Weechat version >= 2.9
-                    return _askTotp(totpRequested)
-                    .then(function(totp) {
-                        if (passwordMethod == "pbkdf2+sha512") {
-                            return _initializeConnection29(passwd, nonce, iterations, totp);
-                        } else if (passwordMethod == "plain") {
-                            return _initializeConnectionPre29(passwd, totp);
-                        }
-                    });
-                }
+                    }
+                });
             }).then(function(){
                 // The Init was sent, weechat will not respond
                 // Wait until either the connection closes

--- a/src/js/glowingbear.js
+++ b/src/js/glowingbear.js
@@ -57,8 +57,6 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         'port': 9001,
         'path': 'weechat',
         'tls': (window.location.protocol === "https:"),
-        'compatibilityWeechat28': false,
-        'useTotp': false,
         'savepassword': false,
         'autoconnect': false,
         'nonicklist': utils.isMobileUi(),
@@ -696,15 +694,6 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         }
     };
 
-    settings.addCallback('useTotp', function() {
-        if (settings.useTotp) {
-            settings.autoconnect = false;
-        }
-    });
-
-    $scope.parseTotp = function() {
-        $scope.totpInvalid = !/^\d{4,10}$/.test($scope.totp);
-    };
 
     $scope.parseHash = function() {
 
@@ -743,8 +732,7 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         $rootScope.bufferBottom = true;
         $scope.connectbutton = 'Connecting';
         $scope.connectbuttonicon = 'glyphicon-refresh glyphicon-spin';
-        connection.connect(settings.host, settings.port, settings.path, $scope.password, settings.tls, settings.useTotp, $scope.totp);
-        $scope.totp = ""; // Clear for next time
+        connection.connect(settings.host, settings.port, settings.path, $scope.password, settings.tls);
     };
 
     $scope.disconnect = function() {

--- a/src/js/glowingbear.js
+++ b/src/js/glowingbear.js
@@ -533,17 +533,12 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         fullName = fullName.substring(0, fullName.lastIndexOf('.') + 1) + bufferName;  // substitute the last part
 
         if (!$scope.setActiveBuffer(fullName, 'fullName')) {
-            // WeeChat 0.4.0+ supports /join -noswitch
-            // As Glowing Bear requires 0.4.2+, we don't need to check the version
             var command = 'join -noswitch';
 
             // Check if it's a query and we need to use /query instead
             if (['#', '&', '+', '!'].indexOf(bufferName.charAt(0)) < 0) {  // these are the characters a channel name can start with (RFC 2813-2813)
-                command = 'query';
-                // WeeChat 1.2+ supports /query -noswitch. See also #577 (different context)
-                if ((models.version[0] == 1 && models.version[1] >= 2) || models.version[1] > 1) {
-                    command += " -noswitch";
-                }
+                // /query -noswitch is supported since WeeChat 1.2; we require 2.9+
+                command = 'query -noswitch';
             }
             connection.sendMessage('/' + command + ' ' + bufferName);
         }

--- a/src/js/glowingbear.js
+++ b/src/js/glowingbear.js
@@ -78,7 +78,6 @@ weechat.controller('WeechatCtrl', ['$rootScope', '$scope', '$store', '$timeout',
         "currentlyViewedBuffers":{},
         'iToken': '',
         'iAlb': '',
-        'freenodeWarningRead': '',
     });
     $scope.settings = settings;
 

--- a/src/js/models.js
+++ b/src/js/models.js
@@ -558,16 +558,12 @@ models.service('models', ['$rootScope', '$filter', 'bufferResume', function($roo
      * Returns a reference to the currently active buffer that
      * WeeChat understands without crashing, even if it's invalid
      *
-     * @return active buffer pointer (WeeChat 1.0+) or fullname (older versions)
+     * @return active buffer pointer
      */
     this.getActiveBufferReference = function() {
-        if (this.version !== null && this.version[0] >= 1) {
-            // pointers are being validated, they're more reliable than
-            // fullName (e.g. if fullName contains spaces)
-            return "0x"+activeBuffer.id;
-        } else {
-            return activeBuffer.fullName;
-        }
+        // pointers are being validated, they're more reliable than
+        // fullName (e.g. if fullName contains spaces)
+        return "0x"+activeBuffer.id;
     };
 
     /*

--- a/src/js/weechat.js
+++ b/src/js/weechat.js
@@ -660,45 +660,14 @@ WeeChatProtocol.formatHandshake = function(params) {
 };
 
 /**
- * Formats an init command for weechat versions < 2.9
+ * Formats an init command
  *
  * @param params Parameters:
- *            password: password (optional)
- *            compression: compression ('off' or 'zlib') (optional)
- *            totp: One Time Password (optional)
- * @return Formatted init command string
- */
-WeeChatProtocol.formatInitPre29 = function(params) {
-    var defaultParams = {
-        password: null,
-        compression: 'zlib',
-        totp: null
-    };
-    var keys = [];
-    var parts = [];
-
-    params = WeeChatProtocol._mergeParams(defaultParams, params);
-    keys.push('compression=' + params.compression);
-    if (params.password !== null) {
-        keys.push('password=' + params.password);
-    }
-    if (params.totp !== null) {
-        keys.push('totp=' + params.totp);
-    }
-    parts.push(keys.join(','));
-
-    return WeeChatProtocol._formatCmd(null, 'init', parts);
-};
-
-/**
- * Formats an init command for weechat versions >= 2.9
- *
- * @param params Parameters:
- *            password_hash: hash of password with method and salt
+ *            password_hash: hash of password with method and salt (e.g. "plain:PASSWORD" or "pbkdf2+sha512:SALT:ITER:HASH")
  *            totp: One Time Password (can be null)
  * @return Formatted init command string
  */
-WeeChatProtocol.formatInit29 = function(password_hash, totp) {
+WeeChatProtocol.formatInit = function(password_hash, totp) {
     var keys = [];
     var parts = [];
 


### PR DESCRIPTION
Six cleanup commits:

### Remove stale Libera Chat migration banner
The Freenode→Libera Chat migration happened years ago. Drops the dismissable banner and the `freenodeWarningRead` setting that tracked its dismissed state.

### Remove WeeChat 2.8 compat mode
WeeChat 2.9 was released in July 2020. The opt-in compatibility checkbox for the pre-2.9 plain-text init path is no longer warranted.

- Drop the 'Compatibility with Weechat 2.8 and older' checkbox and nested 'Use TOTP' sub-checkbox from the connection form
- Remove the compat section from the Getting Started docs
- Update the `oldWeechatError` message to just say "please update WeeChat"
- Remove `compatibilityWeechat28` / `useTotp` from settings defaults and the `useTotp` autoconnect callback
- Remove `parseTotp` / `totpInvalid` / `$scope.totp` (only existed to gate the Connect button in the compat-TOTP flow)
- Simplify `connection.js`: always perform the handshake; collapse the `weechatPre2_9` branches

### Update minimum WeeChat version to 2.9 everywhere
With compat mode gone, 2.9 is the hard minimum. Updated: `CLAUDE.md`, `README.md`, `src/index.html`, and two dead version guards in `glowingbear.js` / `models.js` that were unconditionally true at 2.9+ (dropped the `/query -noswitch` version check and the `getActiveBufferReference` else-branch).

### Fix plain-auth init to use 2.9+ wire format
The compat-mode removal left `_initializeConnectionPre29` handling the `"plain"` password path (non-secure http:// contexts), but it was sending the old `init password=…` format. WeeChat 2.9+, after a handshake, expects `init password_hash=plain:PASSWORD`. Fixed by replacing the call with `formatInit('plain:' + passwd, totp)`.

### Remove formatInitPre29, rename formatInit29 → formatInit
`formatInitPre29` (the old `init password=…` wire format) has no callers; deleted. `formatInit29` is now the only init formatter so the version suffix is dropped: renamed to `formatInit`.

### Rename _initializeConnection29 → _initializeConnection
Version suffix is no longer meaningful now that the pre-2.9 path is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)