### PR TITLE
Fix sticky reconnect banner by nulling stale WebSocket handlers on re…

### DIFF
--- a/src/js/websockets.js
+++ b/src/js/websockets.js
@@ -120,6 +120,12 @@ function($rootScope, $q) {
                            protocol_,
                            properties) {
 
+        if (ws !== null && ws.readyState !== WebSocket.CLOSED) {
+            ws.onclose = null;
+            ws.onerror = null;
+            ws.onmessage = null;
+            ws.close();
+        }
         ws = new WebSocket(url);
         protocol = protocol_;
         for (var property in properties) {


### PR DESCRIPTION
…connect

When websockets.js connect() is called during a reconnect, it now nulls the old WebSocket's event handlers (onclose, onerror, onmessage) before closing it. Previously, the old onclose handler would fire asynchronously after the new WebSocket had already connected and cleared the reconnect banner (reconnecting=false). The stale onclose would then call reconnect() again, setting reconnecting=true and sticking the banner.

This also prevents the stale onclose from:
- Setting locked=false (allowing duplicate WebSocket connections)
- Calling models.reinitialize() (clearing already-loaded buffers)
- Scheduling spurious reconnect timers

Fixes #1308 